### PR TITLE
Fix ZClassic-vs-Zcash correctness (explorer links, conf peer, params, version) + beta5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ workspace.code-workspace
 .DS_Store
 *.mak
 *.plist
+!res/Info.plist
 zclassicd

--- a/res/Info.plist
+++ b/res/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleName</key><string>zclwallet</string>
   <key>CFBundleDisplayName</key><string>ZclWallet</string>
   <key>CFBundleShortVersionString</key><string>2.1.2</string>
-  <key>CFBundleVersion</key><string>2.1.2-beta4</string>
+  <key>CFBundleVersion</key><string>2.1.2-beta5</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>CFBundleIconFile</key><string>logo.icns</string>
   <key>LSMinimumSystemVersion</key><string>11.0</string>

--- a/res/Info.plist
+++ b/res/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key><string>zclwallet</string>
+  <key>CFBundleIdentifier</key><string>org.zclassic.zclwallet</string>
+  <key>CFBundleName</key><string>zclwallet</string>
+  <key>CFBundleDisplayName</key><string>ZclWallet</string>
+  <key>CFBundleShortVersionString</key><string>2.1.2</string>
+  <key>CFBundleVersion</key><string>2.1.2-beta4</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleIconFile</key><string>logo.icns</string>
+  <key>LSMinimumSystemVersion</key><string>11.0</string>
+  <key>NSHighResolutionCapable</key><true/>
+  <key>NSPrincipalClass</key><string>NSApplication</string>
+</dict>
+</plist>

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -182,7 +182,10 @@ void ConnectionLoader::createZClassicConf() {
     QTextStream out(&file); 
     
     out << "server=1\n";
-    out << "addnode=mainnet.z.cash\n";
+    // No addnode here: mainnet.z.cash is a Zcash (ZEC) node, not a valid ZClassic
+    // peer, and the zclassicd we drive already pins its own compiled bootstrap
+    // peers / seeds as -addnode on every start. Baking a wrong peer into the
+    // user's permanent conf only causes repeated failed connections.
     out << "rpcuser=zcl-qt-wallet\n";
     out << "rpcpassword=" % randomPassword() << "\n";
     if (!datadir.isEmpty()) {
@@ -282,18 +285,25 @@ void ConnectionLoader::doNextDownload(std::function<void(void)> cb) {
     
     // Download Finished
     QObject::connect(currentDownload, &QNetworkReply::finished, [=] () {
-        // Rename file
         main->logger->write("Finished downloading " + filename);
-        currentOutput->rename(QDir(paramsDir).filePath(filename));
-
+        // Flush and close the .part file BEFORE deciding what to do with it.
         currentOutput->close();
-        currentDownload->deleteLater();
-        currentOutput->deleteLater();
 
         if (currentDownload->error()) {
-            main->logger->write("Downloading " + filename + " failed");
-            this->showError(QObject::tr("Downloading ") + filename + QObject::tr(" failed. Please check the help site for more info"));                
+            // Drop the partial/truncated .part so it is re-downloaded next run,
+            // instead of promoting it to the final name where verifyParams()
+            // (existence-only) would treat the corrupt file as valid and the user
+            // would later hit an opaque proving-system failure when spending.
+            main->logger->write("Downloading " + filename + " failed; removing partial file");
+            currentOutput->remove();
+            currentDownload->deleteLater();
+            currentOutput->deleteLater();
+            this->showError(QObject::tr("Downloading ") + filename + QObject::tr(" failed. Please check the help site for more info"));
         } else {
+            // Promote .part -> final name only on a fully successful download.
+            currentOutput->rename(QDir(paramsDir).filePath(filename));
+            currentDownload->deleteLater();
+            currentOutput->deleteLater();
             doNextDownload(cb);
         }
     });

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -403,14 +403,9 @@ void MainWindow::setupStatusBar() {
                 QGuiApplication::clipboard()->setText(txid);
             });
             menu.addAction("View tx on block explorer", [=]() {
-                QString url;
-                if (Settings::getInstance()->isTestnet()) {
-                    url = "https://explorer.testnet.z.cash/tx/" + txid;
-                }
-                else {
-                    url = "https://explorer.zcha.in/transactions/" + txid;
-                }
-                QDesktopServices::openUrl(QUrl(url));
+                QString url = Settings::getExplorerTxURL(txid);
+                if (!url.isEmpty())
+                    QDesktopServices::openUrl(QUrl(url));
             });
         }
 
@@ -1133,13 +1128,9 @@ void MainWindow::setupBalancesTab() {
             }
 
             menu.addAction(tr("View on block explorer"), [=] () {
-                QString url;
-                if (Settings::getInstance()->isTestnet()) {
-                    url = "https://explorer.testnet.z.cash/address/" + addr;
-                } else {
-                    url = "https://explorer.zcha.in/accounts/" + addr;
-                }
-                QDesktopServices::openUrl(QUrl(url));
+                QString url = Settings::getExplorerAddressURL(addr);
+                if (!url.isEmpty())
+                    QDesktopServices::openUrl(QUrl(url));
             });
         }
 
@@ -1199,13 +1190,9 @@ void MainWindow::setupTransactionsTab() {
         }
 
         menu.addAction(tr("View on block explorer"), [=] () {
-            QString url;
-            if (Settings::getInstance()->isTestnet()) {
-                url = "https://explorer.testnet.z.cash/tx/" + txid;
-            } else {
-                url = "https://explorer.zcha.in/transactions/" + txid;
-            }
-            QDesktopServices::openUrl(QUrl(url));
+            QString url = Settings::getExplorerTxURL(txid);
+            if (!url.isEmpty())
+                QDesktopServices::openUrl(QUrl(url));
         });
 
         if (!memo.isEmpty()) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -202,6 +202,21 @@ QString Settings::getTokenName() {
     }
 }
 
+// ZClassic mainnet block explorer (Insight URL scheme). There is no known live
+// ZClassic testnet explorer, so testnet returns an empty string and callers skip
+// opening a link rather than sending the user to a dead/wrong page.
+QString Settings::getExplorerTxURL(QString txid) {
+    if (Settings::getInstance()->isTestnet())
+        return "";
+    return "https://explorer.zcl.zelcore.io/tx/" + txid;
+}
+
+QString Settings::getExplorerAddressURL(QString addr) {
+    if (Settings::getInstance()->isTestnet())
+        return "";
+    return "https://explorer.zcl.zelcore.io/address/" + addr;
+}
+
 QString Settings::getDonationAddr(bool sapling) {
     if (Settings::getInstance()->isTestnet()) 
         if (sapling)

--- a/src/settings.h
+++ b/src/settings.h
@@ -79,6 +79,12 @@ public:
     static QString getTokenName();
     static QString getDonationAddr(bool sapling);
 
+    // ZClassic block-explorer URLs (single source of truth for all menu actions).
+    // Returns an empty string when no explorer is available (e.g. testnet), in
+    // which case callers should not open a link.
+    static QString getExplorerTxURL(QString txid);
+    static QString getExplorerAddressURL(QString addr);
+
     static double  getMinerFee();
     static double  getZboardAmount();
     static QString getZboardAddr();

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define APP_VERSION "2.1.2-beta4"
+#define APP_VERSION "2.1.2-beta5"

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define APP_VERSION "0.6.3"
+#define APP_VERSION "2.1.2-beta4"


### PR DESCRIPTION
A quality audit of the wallet surfaced several ZClassic-vs-Zcash leftovers and release-blocking staleness. Each fix is independent; the wallet rebuilds clean against Qt 5.15.

### "View on block explorer" opened **Zcash** explorers
All three menu sites (status-bar txid, address context, tx context) opened `explorer.zcha.in` / `explorer.testnet.z.cash`. A ZClassic txid/address there returns **"not found" 100% of the time**. Routed to the live ZClassic explorer `explorer.zcl.zelcore.io` via two new `Settings` helpers (`getExplorerTxURL`/`getExplorerAddressURL`) — one source of truth instead of three copy-pasted blocks that drifted identically. Testnet has no known live explorer, so the helpers return empty and the action no-ops rather than opening a dead link.

### Generated `zclassic.conf` injected a **Zcash** node
`createZClassicConf()` wrote `addnode=mainnet.z.cash` — a Zcash (ZEC) node, not a valid ZClassic peer (different magic/genesis). Dropped: `zclassicd` already pins its own compiled bootstrap peers/seeds as `-addnode` on every start.

### Corrupt zk-params were cached forever
The download-finished handler renamed the truncated `.part` to its final name **before** checking `error()`, and `verifyParams()` only checks existence — so an interrupted ~1.7 GB download produced a corrupt file treated as valid on every later launch, surfacing as an opaque proving-system failure on the first shielded spend. Now the `.part` is promoted to the final name **only on success**, and **deleted on error** so it re-downloads.

### Release/packaging
- `src/version.h` was stale at `0.6.3`, which also makes `mkmacdmg.sh` abort on a version mismatch → bumped to `2.1.2-beta4`.
- Added a curated `res/Info.plist` (the `.pro` references it via `QMAKE_INFO_PLIST`, but `*.plist` was gitignored and the file absent, so Qt silently generated a default bundle with no real identifier/version). Un-ignored it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)