### PR TITLE
Idiotproof + failsafe GUI: onboarding, accurate sync, fund-safety, corrupt-state recovery

### DIFF
--- a/src/confirm.ui
+++ b/src/confirm.ui
@@ -173,6 +173,19 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="publicWarning">
+     <property name="styleSheet">
+      <string notr="true">color: red;</string>
+     </property>
+     <property name="text">
+      <string>This transaction is PUBLIC: the amount and recipient will be permanently visible to everyone on the blockchain.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="warningLabel">
      <property name="styleSheet">
       <string notr="true">color: red;</string>

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -10,6 +10,7 @@
 #include <QStorageInfo>
 #include <QProgressBar>
 #include <QElapsedTimer>
+#include <QStringList>
 
 using json = nlohmann::json;
 
@@ -89,6 +90,12 @@ void ConnectionLoader::doAutoConnect(bool tryEzclassicdStart) {
     if (config.get() != nullptr) {
         auto connection = makeConnection(config);
 
+        // P2-1: remember the datadir (holds blocks/, chainstate/, debug.log and
+        // wallet.dat) so the corruption failsafe can read debug.log and back up
+        // wallet.dat if the node dies before the RPC connection comes up.
+        if (ezDataDir.isEmpty() && !config->zclassicDir.isEmpty())
+            ezDataDir = config->zclassicDir;
+
         refreshZClassicdState(connection, [=] () {
             // Connection refused: the embedded node either has not started yet, or
             // it is alive but still warming up -- binding its RPC port can take ~1
@@ -130,14 +137,11 @@ void ConnectionLoader::doAutoConnect(bool tryEzclassicdStart) {
                 return;
             }
 
-            // Process is genuinely dead and the warmup window elapsed -> friendly error.
+            // Process is genuinely dead and the warmup window elapsed. Before
+            // showing a generic error, look at WHY it died: a corrupt or
+            // partway block/chainstate database has a safe, staged repair path.
             main->logger->write("Embedded zclassicd exited and did not come online");
-            QString detail = ezclassicd ? ezclassicd->errorString() : QString();
-            this->showError(QObject::tr("ZClassic couldn't finish starting up.\n\n"
-                "This usually clears up on its own — please quit and open ZClassic again. "
-                "If it keeps happening, make sure you have enough free disk space and a working "
-                "internet connection.")
-                % (detail.isEmpty() ? QString("") : QString("\n\n(") % detail % QString(")")));
+            this->handleStartupFailure();
         });
     } else {
         if (Settings::getInstance()->useEmbedded()) {
@@ -420,32 +424,27 @@ void ConnectionLoader::doNextDownload(std::function<void(void)> cb) {
     });
 }
 
-bool ConnectionLoader::startEmbeddedZClassicd() {
-    if (!Settings::getInstance()->useEmbedded()) 
+bool ConnectionLoader::startEmbeddedZClassicd(const QStringList& extraArgs) {
+    if (!Settings::getInstance()->useEmbedded())
         return false;
-    
-    main->logger->write("Trying to start embedded zclassicd");
 
-    // Static because it needs to survive even after this method returns.
-    static QString processStdErrOutput;
+    main->logger->write("Trying to start embedded zclassicd");
 
     if (ezclassicd != nullptr) {
         if (ezclassicd->state() == QProcess::NotRunning) {
-            if (!processStdErrOutput.isEmpty()) {
-                main->logger->write("node stderr: " + processStdErrOutput);
-                QMessageBox::critical(main, QObject::tr("ZClassic"),
-                                      QObject::tr("Your wallet had trouble starting up.\n\n"
-                                      "Please open ZClassic again. If it keeps happening, make sure your "
-                                      "security software isn't blocking it and that you have free disk space."),
-                                      QMessageBox::Ok);
-            }
+            // The node object already exists but the process is dead. This is the
+            // failsafe's job now: handleStartupFailure() inspects stderr/debug.log
+            // and offers a staged repair. We do NOT show a generic dialog here, and
+            // we do NOT relaunch the same dead QProcess. Caller handles the result.
+            if (!ezStdErr.isEmpty())
+                main->logger->write("node stderr: " + ezStdErr);
             return false;
         } else {
             return true;
-        }        
+        }
     }
 
-    // Finally, start zclassicd    
+    // Finally, start zclassicd
     QDir appPath(QCoreApplication::applicationDirPath());
 #ifdef Q_OS_LINUX
     auto zclassicdProgram = appPath.absoluteFilePath("zqw-zclassicd");
@@ -457,43 +456,325 @@ bool ConnectionLoader::startEmbeddedZClassicd() {
 #else
     auto zclassicdProgram = appPath.absoluteFilePath("zclassicd.exe");
 #endif
-    
+
     if (!QFile(zclassicdProgram).exists()) {
         qDebug() << "Can't find zclassicd at " << zclassicdProgram;
-        main->logger->write("Can't find zclassicd at " + zclassicdProgram); 
+        main->logger->write("Can't find zclassicd at " + zclassicdProgram);
         return false;
     }
 
-    ezclassicd = new QProcess(main);    
+    // Reset per-launch failsafe state so each (re)launch is judged on its own output.
+    ezNodeQuitDuringStartup = false;
+    ezStdErr.clear();
+
+    ezclassicd = new QProcess(main);
     QObject::connect(ezclassicd, &QProcess::started, [=] () {
         //qDebug() << "zclassicd started";
     });
 
+    // A. DETECT: if the node EXITS before the RPC connection is established (i.e.
+    // while ezWarmupTimer is still inside its window), record that it quit during
+    // startup. doRPCSetConnection() clears ezWarmupTimer when RPC succeeds, so a
+    // 'finished' after that is a normal shutdown and is ignored here.
     QObject::connect(ezclassicd, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
-                        [=](int, QProcess::ExitStatus) {
-        //qDebug() << "zclassicd finished with code " << exitCode << "," << exitStatus;    
+                        [=](int exitCode, QProcess::ExitStatus exitStatus) {
+        main->logger->write(QString("zclassicd finished: code=%1 status=%2")
+                            .arg(exitCode).arg((int)exitStatus));
+        // Drain any final stderr the readyRead signal hasn't delivered yet.
+        if (ezclassicd) ezStdErr.append(ezclassicd->readAllStandardError());
+        if (ezWarmupTimer.isValid())
+            ezNodeQuitDuringStartup = true;   // died before we ever connected
     });
 
-    QObject::connect(ezclassicd, &QProcess::errorOccurred, [&] (auto) {
-        //qDebug() << "Couldn't start zclassicd: " << error;
+    // A. DETECT: failure to even launch (missing exec permission, AV block, etc.).
+    QObject::connect(ezclassicd, &QProcess::errorOccurred, [=] (QProcess::ProcessError error) {
+        main->logger->write(QString("zclassicd errorOccurred: %1 (%2)")
+                            .arg((int)error)
+                            .arg(ezclassicd ? ezclassicd->errorString() : QString()));
+        if (ezWarmupTimer.isValid())
+            ezNodeQuitDuringStartup = true;
     });
 
     QObject::connect(ezclassicd, &QProcess::readyReadStandardError, [=]() {
         auto output = ezclassicd->readAllStandardError();
-       main->logger->write("zclassicd stderr:" + output);
-        processStdErrOutput.append(output);
+        main->logger->write("zclassicd stderr:" + output);
+        ezStdErr.append(output);
     });
 
 #ifdef Q_OS_LINUX
-    ezclassicd->start(zclassicdProgram);
+    ezclassicd->start(zclassicdProgram, extraArgs);
 #elif defined(Q_OS_DARWIN)
-    ezclassicd->start(zclassicdProgram);
+    ezclassicd->start(zclassicdProgram, extraArgs);
 #else
     ezclassicd->setWorkingDirectory(appPath.absolutePath());
-    ezclassicd->start("zclassicd.exe");
+    ezclassicd->start("zclassicd.exe", extraArgs);
 #endif // Q_OS_LINUX
 
 
+    return true;
+}
+
+// A./B. Detect-and-classify entry point. Called from doAutoConnect once the node
+// is confirmed dead and the warmup window has elapsed. Reads the captured stderr
+// plus the tail of <datadir>/debug.log, scans for corruption markers, and either
+// offers the staged repair ladder (corruption) or shows the existing generic
+// friendly error (everything else).
+void ConnectionLoader::handleStartupFailure() {
+    // Pull the last of the daemon's diagnostics from disk too: stderr may be empty
+    // if the daemon logged the corruption only to debug.log before aborting.
+    QString diag = ezStdErr;
+    QString logTail = readDebugLogTail();
+    if (!logTail.isEmpty())
+        diag += "\n" + logTail;
+
+    main->logger->write(QString("Startup failure classification; quitDuringStartup=%1, diag bytes=%2")
+                        .arg(ezNodeQuitDuringStartup).arg(diag.size()));
+
+    // Disk full: a repair (reindex/re-download) needs MORE space, so it would only
+    // fail again or make things worse. Never offer a repair here — say so plainly.
+    qint64 freeBytes = ezDataDir.isEmpty() ? -1 : QStorageInfo(resolveDataSubdir()).bytesAvailable();
+    if (diag.contains("Disk space is low", Qt::CaseInsensitive) ||
+        (freeBytes >= 0 && freeBytes < (qint64)2 * 1024 * 1024 * 1024)) {
+        this->showError(QObject::tr("ZClassic is running low on disk space.\n\n"
+            "Please free up several gigabytes on this drive, then open ZClassic again. "
+            "Your wallet and coins are safe."));
+        return;
+    }
+
+    // Another copy is already using this data folder (a second wallet window, or a
+    // manually started zclassicd). A repair is the wrong action — point at that.
+    if (diag.contains("probably already running", Qt::CaseInsensitive) ||
+        diag.contains("Cannot obtain a lock", Qt::CaseInsensitive)) {
+        this->showError(QObject::tr("ZClassic may already be running.\n\n"
+            "Please close any other ZClassic windows (or wait a moment and try again), "
+            "then reopen it. Your wallet and coins are safe."));
+        return;
+    }
+
+    // C. If it looks like a corrupt / partway database, offer the staged repair.
+    // Only offer once per run so a user who declines isn't trapped in a loop, and
+    // cap repeated attempts across runs so a failing disk can't loop a heavy rebuild.
+    if (!ezRepairOffered && looksLikeDbCorruption(diag)) {
+        if (QSettings().value("repair/attempts", 0).toInt() >= 3) {
+            this->showError(QObject::tr("ZClassic tried to repair its blockchain data several "
+                "times but couldn't fix it, which can mean a failing disk.\n\n"
+                "Your wallet and coins are safe (a backup copy of your wallet was saved next "
+                "to it). You may want to copy your wallet file somewhere safe and have this "
+                "computer's disk checked."));
+            return;
+        }
+        ezRepairOffered = true;
+        this->offerCorruptionRepair();
+        return;
+    }
+
+    // Otherwise: the original generic, reassuring message.
+    QString detail = ezclassicd ? ezclassicd->errorString() : QString();
+    this->showError(QObject::tr("ZClassic couldn't finish starting up.\n\n"
+        "This usually clears up on its own — please quit and open ZClassic again. "
+        "If it keeps happening, make sure you have enough free disk space and a working "
+        "internet connection.")
+        % (detail.isEmpty() ? QString("") : QString("\n\n(") % detail % QString(")")));
+}
+
+// B. CLASSIFY: scan captured stderr + debug.log tail for the daemon's known
+// block/chainstate corruption markers (see src/init.cpp). Case-insensitive.
+bool ConnectionLoader::looksLikeDbCorruption(const QString& text) {
+    if (text.isEmpty())
+        return false;
+
+    static const char* markers[] = {
+        "Corrupted block database detected",
+        "Error opening block database",
+        "Error loading block database",
+        "Aborted block database rebuild",
+        "Failed to read block",
+        "System error while flushing",
+        "Do you want to rebuild the block database now"
+    };
+
+    for (auto m : markers) {
+        if (text.contains(QString::fromLatin1(m), Qt::CaseInsensitive))
+            return true;
+    }
+    return false;
+}
+
+// The network data subdirectory: the datadir root for mainnet, or testnet3/ when
+// that subdir actually holds the chain/wallet. We probe the filesystem rather than
+// Settings::isTestnet() because isTestnet() is only set from the getinfo RPC reply,
+// which never arrives when the node dies during startup.
+QDir ConnectionLoader::resolveDataSubdir() {
+    QDir root(ezDataDir);
+    QDir testnet(QDir(ezDataDir).filePath("testnet3"));
+    if (testnet.exists() &&
+        (QFile::exists(testnet.filePath("wallet.dat")) ||
+         QFile::exists(testnet.filePath("debug.log")) ||
+         QDir(testnet.filePath("blocks")).exists()))
+        return testnet;
+    return root;
+}
+
+// Read the last maxBytes of <datadir>/debug.log, READ-ONLY. Returns "" if the
+// datadir/log is unknown or unreadable. Never opens any file for writing.
+QString ConnectionLoader::readDebugLogTail(int maxBytes) {
+    if (ezDataDir.isEmpty())
+        return QString();
+
+    QString logPath = resolveDataSubdir().filePath("debug.log");
+
+    QFile log(logPath);
+    if (!log.exists() || !log.open(QIODevice::ReadOnly))
+        return QString();
+
+    qint64 sz = log.size();
+    if (sz > maxBytes)
+        log.seek(sz - maxBytes);
+    QString tail = QString::fromUtf8(log.readAll());
+    log.close();
+    return tail;
+}
+
+// C. OFFER A SAFE, STAGED REPAIR LADDER (least to most invasive). The dialog is
+// plain-language and reassures the user that their wallet/keys are untouched.
+// Step 0 (wallet.dat backup) always runs first inside relaunchForRepair() before
+// any repair flag is applied; if that backup fails, the repair is aborted.
+void ConnectionLoader::offerCorruptionRepair() {
+    main->logger->write("Offering staged corruption repair");
+
+    QMessageBox box(main);
+    box.setWindowTitle(QObject::tr("ZClassic needs a quick repair"));
+    box.setIcon(QMessageBox::Warning);
+    box.setText(QObject::tr("ZClassic couldn't open its blockchain files."));
+    box.setTextFormat(Qt::RichText);
+    box.setInformativeText(QObject::tr(
+        "It looks like the downloaded blockchain data on this computer was left in a "
+        "damaged or half-finished state (this can happen if the app or the computer "
+        "shut down while it was still working).<br><br>"
+        "<b>Your wallet and your coins are safe.</b> The blockchain data is just a local "
+        "copy of the public network and can always be rebuilt. None of these options "
+        "touch your wallet file or private keys — and ZClassic will make a backup copy "
+        "of your wallet first, just to be sure.<br><br>"
+        "How would you like to fix it? Start with the fast option; you can try the next "
+        "one if it doesn't work."));
+
+    // Least-invasive first. AcceptRole/ActionRole keep them in a predictable order.
+    QPushButton* fastBtn   = box.addButton(QObject::tr("Repair (fast)"),            QMessageBox::AcceptRole);
+    QPushButton* rebuildBtn= box.addButton(QObject::tr("Rebuild index (slower)"),   QMessageBox::ActionRole);
+    QPushButton* redownBtn = box.addButton(QObject::tr("Re-download blockchain"),   QMessageBox::ActionRole);
+    box.addButton(QObject::tr("Not now"),                                           QMessageBox::RejectRole);
+    box.setDefaultButton(fastBtn);
+
+    box.exec();
+    QAbstractButton* clicked = box.clickedButton();
+
+    if (clicked == fastBtn) {
+        // Step 1: rebuild ONLY the chainstate/UTXO set from the existing block files.
+        this->relaunchForRepair(QStringList() << "-reindex-chainstate");
+    } else if (clicked == rebuildBtn) {
+        // Step 2: rebuild the block index too (from the blk files). Slower.
+        this->relaunchForRepair(QStringList() << "-reindex");
+    } else if (clicked == redownBtn) {
+        // Step 3 (last resort): let the daemon's own bootstrap/backup machinery move
+        // the chain data aside and re-fetch. -reindex is a safe, non-destructive
+        // trigger that hands control to that machinery; it NEVER touches wallet.dat.
+        auto confirm = QMessageBox::question(main, QObject::tr("Re-download the blockchain?"),
+            QObject::tr("This rebuilds the blockchain from scratch and can take a while. "
+                "It still does not touch your wallet or private keys.\n\nContinue?"),
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        if (confirm == QMessageBox::Yes)
+            this->relaunchForRepair(QStringList() << "-reindex");
+    } else { // "Not now" or dialog closed
+        this->showError(QObject::tr("ZClassic couldn't finish starting up.\n\n"
+            "You can open ZClassic again whenever you're ready, and choose a repair "
+            "option then. Your wallet and coins are safe."));
+    }
+}
+
+// Step 0 + relaunch. ALWAYS back up wallet.dat (read+copy) first; only if that
+// succeeds do we apply the one-shot repair flag and relaunch the node ONCE.
+// The flag is passed only to this next start and is never written to zclassic.conf.
+void ConnectionLoader::relaunchForRepair(const QStringList& extraArgs) {
+    // GUARD RAIL: never proceed to a repair without a fresh wallet.dat backup.
+    if (!backupWalletForRepair()) {
+        this->showError(QObject::tr("ZClassic couldn't make a safety backup of your wallet, "
+            "so the repair was stopped.\n\n"
+            "Your wallet and coins have not been changed. Please make sure you have free "
+            "disk space and try again."));
+        return;
+    }
+
+    // Count this repair attempt (persisted per install) so handleStartupFailure
+    // can stop escalating after a few failures instead of looping a heavy rebuild.
+    QSettings().setValue("repair/attempts", QSettings().value("repair/attempts", 0).toInt() + 1);
+
+    main->logger->write("Relaunching embedded node for repair with args: " + extraArgs.join(" "));
+
+    // Drop the dead QProcess so startEmbeddedZClassicd() creates a fresh one with
+    // the one-shot repair flag. We never reuse or relaunch the old process object.
+    if (ezclassicd) {
+        ezclassicd->deleteLater();
+        ezclassicd = nullptr;
+    }
+    ezNodeQuitDuringStartup = false;
+    ezStdErr.clear();
+
+    this->showInformation(QObject::tr("Repairing your blockchain data…"),
+        QObject::tr("This can take several minutes. Your wallet is safe."));
+
+    if (!this->startEmbeddedZClassicd(extraArgs)) {
+        this->showError(QObject::tr("ZClassic couldn't start the repair.\n\n"
+            "Please open ZClassic again. Your wallet and coins are safe."));
+        return;
+    }
+
+    // Re-arm the warmup window and resume the normal patient polling loop, which
+    // will now connect once the reindex completes (or, if it fails again, fall
+    // back through handleStartupFailure() — but ezRepairOffered is already set, so
+    // the user gets the plain error instead of an endless repair loop).
+    ezWarmupTimer.start();
+    QTimer::singleShot(1000, [=]() { doAutoConnect(); });
+}
+
+// HARD INVARIANT enforcement: this is the ONLY code in the failsafe that touches
+// wallet.dat, and it only ever READS it (QFile::copy opens the source read-only)
+// to a timestamped backup beside it. It never deletes, renames, or opens
+// wallet.dat for writing. Returns true on a verified successful copy.
+bool ConnectionLoader::backupWalletForRepair() {
+    if (ezDataDir.isEmpty()) {
+        main->logger->write("Repair backup: datadir unknown, cannot locate wallet.dat");
+        return false;
+    }
+
+    QDir dir = resolveDataSubdir();
+
+    QFile wallet(dir.filePath("wallet.dat"));
+    if (!wallet.exists()) {
+        // No wallet.dat means there is nothing to protect (e.g. a brand-new datadir
+        // that never finished its first run). Safe to proceed with the repair.
+        main->logger->write("Repair backup: no wallet.dat present; nothing to back up");
+        return true;
+    }
+
+    // Make sure we have room for the copy before attempting it.
+    if (!ensureEnoughDiskSpace(dir.absolutePath()))
+        return false;
+
+    QString stamp = QDateTime::currentDateTime().toString("yyyyMMdd-hhmmss");
+    QString backupPath = dir.filePath("wallet.dat.backup-" + stamp);
+
+    // Don't clobber an existing backup of the same second (extremely unlikely).
+    if (QFile::exists(backupPath)) {
+        main->logger->write("Repair backup: target already exists, aborting to avoid overwrite");
+        return false;
+    }
+
+    if (!wallet.copy(backupPath)) {
+        main->logger->write("Repair backup: copy failed: " + wallet.errorString());
+        return false;
+    }
+
+    main->logger->write("Repair backup: wallet.dat copied to " + backupPath);
     return true;
 }
 
@@ -526,9 +807,26 @@ void ConnectionLoader::doManualConnect() {
 }
 
 void ConnectionLoader::doRPCSetConnection(Connection* conn) {
+    // The RPC connection is now live: the node is genuinely up, so end the warmup
+    // window. After this, a QProcess 'finished' signal is a normal shutdown, not a
+    // startup quit, and must NOT trigger the corruption failsafe.
+    ezWarmupTimer.invalidate();
+    ezNodeQuitDuringStartup = false;
+
+    // This ConnectionLoader is about to be deleted (delete this, below), but its
+    // lambdas are still connected to ezclassicd's finished/errorOccurred/readyRead
+    // signals. Disconnect them so a later signal (a normal shutdown or a runtime
+    // crash) can't call into freed memory. rpc, which takes ownership next, only
+    // polls the process and connects no signals of its own.
+    if (ezclassicd)
+        QObject::disconnect(ezclassicd, nullptr, nullptr, nullptr);
+
+    // Successful startup: clear the persistent repair-attempt counter.
+    QSettings().setValue("repair/attempts", 0);
+
     rpc->setEZClassicd(ezclassicd);
     rpc->setConnection(conn);
-    
+
     d->accept();
 
     delete this;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -46,54 +46,53 @@ void ConnectionLoader::doAutoConnect(bool tryEzclassicdStart) {
         auto connection = makeConnection(config);
 
         refreshZClassicdState(connection, [=] () {
-            // Refused connection. So try and start embedded zclassicd
-            if (Settings::getInstance()->useEmbedded()) {
-                if (tryEzclassicdStart) {
-                    this->showInformation(QObject::tr("Starting embedded zclassicd"));
-                    if (this->startEmbeddedZClassicd()) {
-                        // Embedded zclassicd started up. Wait a second and then refresh the connection
-                        main->logger->write("Embedded zclassicd started up, trying autoconnect in 1 sec");
-                        QTimer::singleShot(1000, [=]() { doAutoConnect(); } );
-                    } else {
-                        if (config->zclassicDaemon) {
-                            // zclassicd is configured to run as a daemon, so we must wait for a few seconds
-                            // to let it start up. 
-                            main->logger->write("zclassicd is daemon=1. Waiting for it to start up");
-                            this->showInformation(QObject::tr("zclassicd is set to run as daemon"), QObject::tr("Waiting for zclassicd"));
-                            QTimer::singleShot(5000, [=]() { doAutoConnect(/* don't attempt to start ezclassicd */ false); });
-                        } else {
-                            // Something is wrong. 
-                            // We're going to attempt to connect to the one in the background one last time
-                            // and see if that works, else throw an error
-                            main->logger->write("Unknown problem while trying to start zclassicd");
-                            QTimer::singleShot(2000, [=]() { doAutoConnect(/* don't attempt to start ezclassicd */ false); });
-                        }
-                    }
-                } else {
-                    // We tried to start ezclassicd previously, and it didn't work. So, show the error. 
-                    main->logger->write("Couldn't start embedded zclassicd for unknown reason");
-                    QString explanation;
-                    if (config->zclassicDaemon) {
-                        explanation = QString() % QObject::tr("You have zclassicd set to start as a daemon, which can cause problems "
-                            "with ZclWallet\n\n."
-                            "Please remove the following line from your zclassic.conf and restart ZclWallet\n"
-                            "daemon=1");
-                    } else {
-                        explanation = QString() % QObject::tr("Couldn't start the embedded zclassicd.\n\n" 
-                            "Please try restarting.\n\nIf you previously started zclassicd with custom arguments, you might need to reset zclassic.conf.\n\n" 
-                            "If all else fails, please run zclassicd manually.") %  
-                            (ezclassicd ? QObject::tr("The process returned") + ":\n\n" % ezclassicd->errorString() : QString(""));
-                    }
-                    
-                    this->showError(explanation);
-                }                
-            } else {
-                // zclassic.conf exists, there's no connection, and the user asked us not to start zclassicd. Error!
+            // Connection refused: the embedded node either has not started yet, or
+            // it is alive but still warming up -- binding its RPC port can take ~1
+            // minute while it loads the block index. Be patient and reassuring;
+            // NEVER show a scary error while the node is alive or within a warmup
+            // window. (Previously a transient refused during normal warmup could
+            // fire a false "Couldn't start the embedded zclassicd" on first launch.)
+            if (!Settings::getInstance()->useEmbedded()) {
                 main->logger->write("Not using embedded and couldn't connect to zclassicd");
-                QString explanation = QString() % QObject::tr("Couldn't connect to zclassicd configured in zclassic.conf.\n\n" 
-                                      "Not starting embedded zclassicd because --no-embedded was passed");
-                this->showError(explanation);
+                this->showError(QObject::tr("Couldn't connect to the ZClassic node configured in "
+                    "zclassic.conf, and the built-in node is turned off (--no-embedded)."));
+                return;
             }
+
+            // Never started yet -> start it once.
+            if (ezclassicd == nullptr) {
+                this->showInformation(QObject::tr("Starting your ZClassic node…"));
+                if (!this->startEmbeddedZClassicd()) {
+                    main->logger->write("Could not launch the embedded zclassicd binary");
+                    this->showError(QObject::tr("ZClassic couldn't start its node.\n\n"
+                        "Please reinstall the app. If the problem continues, make sure your "
+                        "security software isn't blocking it."));
+                    return;
+                }
+                ezWarmupTimer.start();
+                QTimer::singleShot(1000, [=]() { doAutoConnect(); });
+                return;
+            }
+
+            // Started, RPC not answering yet. While the process is alive -- or within
+            // a generous warmup window after it forked into the background -- keep
+            // polling with a friendly message instead of ever showing an error.
+            if (ezclassicd->state() != QProcess::NotRunning ||
+                (ezWarmupTimer.isValid() && ezWarmupTimer.elapsed() < 120000)) {
+                this->showInformation(QObject::tr("Starting your ZClassic node…"),
+                    QObject::tr("Almost ready — preparing the blockchain (this can take a minute)…"));
+                QTimer::singleShot(1000, [=]() { doAutoConnect(); });
+                return;
+            }
+
+            // Process is genuinely dead and the warmup window elapsed -> friendly error.
+            main->logger->write("Embedded zclassicd exited and did not come online");
+            QString detail = ezclassicd ? ezclassicd->errorString() : QString();
+            this->showError(QObject::tr("ZClassic couldn't finish starting up.\n\n"
+                "This usually clears up on its own — please quit and open ZClassic again. "
+                "If it keeps happening, make sure you have enough free disk space and a working "
+                "internet connection.")
+                % (detail.isEmpty() ? QString("") : QString("\n\n(") % detail % QString(")")));
         });
     } else {
         if (Settings::getInstance()->useEmbedded()) {
@@ -471,7 +470,7 @@ void ConnectionLoader::refreshZClassicdState(Connection* connection, std::functi
                     if (dots > 3)
                         dots = 0;
                 }
-                this->showInformation(QObject::tr("Your zclassicd is starting up. Please wait."), status);
+                this->showInformation(QObject::tr("Your ZClassic node is starting up. Please wait."), status);
                 main->logger->write("Waiting for zclassicd to come online.");
                 // Refresh after one second
                 QTimer::singleShot(1000, [=]() { this->refreshZClassicdState(connection, refused); });

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -7,6 +7,10 @@
 
 #include "precompiled.h"
 
+#include <QStorageInfo>
+#include <QProgressBar>
+#include <QElapsedTimer>
+
 using json = nlohmann::json;
 
 ConnectionLoader::ConnectionLoader(MainWindow* main, RPC* rpc) {
@@ -18,6 +22,46 @@ ConnectionLoader::ConnectionLoader(MainWindow* main, RPC* rpc) {
     connD->setupUi(d);
     QPixmap logo(":/img/res/logobig.gif");
     connD->topIcon->setBasePixmap(logo.scaled(256, 256, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+
+    // ---- P1-1: friendly, non-scary staged-onboarding card (built in C++ so the
+    // checked-in connection.ui / ui_connection.h stay untouched). It is shown on
+    // first run only and stays visible through the initial sync. ----
+    ezCard = new QLabel(d);
+    ezCard->setWordWrap(true);
+    ezCard->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    ezCard->setTextFormat(Qt::RichText);
+    ezCard->setContentsMargins(16, 8, 16, 8);
+    ezCard->setText(QObject::tr(
+        "<b>Setting up ZClassic</b><br>"
+        "The first run takes about <b>10–20 minutes</b> while your wallet "
+        "prepares itself. You can leave it running — it is safe to come back later.<br><br>"
+        "&nbsp;&nbsp;<b>Step 1.</b> Getting the security files ready<br>"
+        "&nbsp;&nbsp;<b>Step 2.</b> Starting your wallet<br>"
+        "&nbsp;&nbsp;<b>Step 3.</b> Catching up with the network"));
+
+    ezProgress = new QProgressBar(d);
+    ezProgress->setTextVisible(false);
+    // Busy / indeterminate by default; switched to a real 0-100 bar once we have
+    // an actual percentage (param download % or block-sync %).
+    ezProgress->setRange(0, 0);
+
+    // Insert the card above, and the progress bar below, the status labels.
+    // verticalLayout order today: topIcon, line_2, status, statusDetail, line.
+    // We want: topIcon, line_2, [ezCard], status, statusDetail, [ezProgress], line.
+    int statusIdx = connD->verticalLayout->indexOf(connD->status);
+    if (statusIdx < 0) statusIdx = 2;
+    connD->verticalLayout->insertWidget(statusIdx, ezCard);
+    int lineIdx = connD->verticalLayout->indexOf(connD->line);
+    if (lineIdx < 0) lineIdx = connD->verticalLayout->count();
+    connD->verticalLayout->insertWidget(lineIdx, ezProgress);
+
+    // Only show the explanatory card the very first time the user ever launches.
+    bool firstRun = !QSettings().value("ez/onboardingShown", false).toBool();
+    ezCard->setVisible(firstRun);
+    if (firstRun)
+        QSettings().setValue("ez/onboardingShown", true);
+
+    d->setMinimumWidth(540);
 }
 
 ConnectionLoader::~ConnectionLoader() {    
@@ -54,14 +98,15 @@ void ConnectionLoader::doAutoConnect(bool tryEzclassicdStart) {
             // fire a false "Couldn't start the embedded zclassicd" on first launch.)
             if (!Settings::getInstance()->useEmbedded()) {
                 main->logger->write("Not using embedded and couldn't connect to zclassicd");
-                this->showError(QObject::tr("Couldn't connect to the ZClassic node configured in "
-                    "zclassic.conf, and the built-in node is turned off (--no-embedded)."));
+                this->showError(QObject::tr("ZClassic couldn't connect.\n\n"
+                    "It is set to use an outside connection that isn't responding. "
+                    "Please check your internet connection and try opening ZClassic again."));
                 return;
             }
 
             // Never started yet -> start it once.
             if (ezclassicd == nullptr) {
-                this->showInformation(QObject::tr("Starting your ZClassic node…"));
+                this->showInformation(QObject::tr("Step 2 of 3: Starting your wallet…"));
                 if (!this->startEmbeddedZClassicd()) {
                     main->logger->write("Could not launch the embedded zclassicd binary");
                     this->showError(QObject::tr("ZClassic couldn't start its node.\n\n"
@@ -79,8 +124,8 @@ void ConnectionLoader::doAutoConnect(bool tryEzclassicdStart) {
             // polling with a friendly message instead of ever showing an error.
             if (ezclassicd->state() != QProcess::NotRunning ||
                 (ezWarmupTimer.isValid() && ezWarmupTimer.elapsed() < 120000)) {
-                this->showInformation(QObject::tr("Starting your ZClassic node…"),
-                    QObject::tr("Almost ready — preparing the blockchain (this can take a minute)…"));
+                this->showInformation(QObject::tr("Step 2 of 3: Starting your wallet…"),
+                    QObject::tr("Almost ready — getting things going (this can take a minute)…"));
                 QTimer::singleShot(1000, [=]() { doAutoConnect(); });
                 return;
             }
@@ -200,6 +245,15 @@ void ConnectionLoader::createZClassicConf() {
 
 void ConnectionLoader::downloadParams(std::function<void(void)> cb) {    
     main->logger->write("Adding params to download queue");
+
+    // P1-7: make sure there is enough room before pulling ~1.7GB of security files.
+    if (!ensureEnoughDiskSpace(zcashParamsDir()))
+        return;
+
+    // P1-1: this is Step 1 of onboarding.
+    this->showInformation(QObject::tr("Step 1 of 3: Getting the security files ready…"),
+                          QObject::tr("This is a one-time download of about 1.7 GB."));
+
     // Add all the files to the download queue
     downloadQueue = new QQueue<QUrl>();
     client = new QNetworkAccessManager(main);   
@@ -223,22 +277,30 @@ void ConnectionLoader::doNextDownload(std::function<void(void)> cb) {
 
     if (downloadQueue->isEmpty()) {
         delete downloadQueue;
+        downloadQueue = nullptr;
         client->deleteLater();
+        client = nullptr;
 
         main->logger->write("All Downloads done");
-        this->showInformation(QObject::tr("All Downloads Finished Successfully!"));
+        ezRetryCount = 0;
+        // Back to a busy bar; the node-start / sync phase has no per-file %.
+        if (ezProgress) ezProgress->setRange(0, 0);
+        this->showInformation(QObject::tr("Step 1 of 3: Security files ready."),
+                              QObject::tr("Starting your wallet…"));
         cb();
         return;
     }
 
-    QUrl url = downloadQueue->dequeue();
-    int filesRemaining = downloadQueue->size();
+    QUrl url = downloadQueue->head();   // peek; only dequeue on success so retries can re-pull
+    int totalFiles = 5;                 // we enqueue 5 param files
+    int fileNumber = totalFiles - downloadQueue->size() + 1;
 
     QString filename = fnSaveFileName(url);
     QString paramsDir = zcashParamsDir();
 
     if (QFile(QDir(paramsDir).filePath(filename)).exists()) {
         main->logger->write(filename + " already exists, skipping");
+        downloadQueue->dequeue();
         doNextDownload(cb);
 
         return;
@@ -249,58 +311,113 @@ void ConnectionLoader::doNextDownload(std::function<void(void)> cb) {
 
     if (!currentOutput->open(QIODevice::WriteOnly)) {
         main->logger->write("Couldn't open " + currentOutput->fileName() + " for writing");
-        this->showError(QObject::tr("Couldn't download params. Please check the help site for more info."));
+        delete currentOutput;
+        currentOutput = nullptr;
+        // P1-2 fix: must NOT fall through after a failed open.
+        this->showError(QObject::tr("ZClassic couldn't save the security files.\n\n"
+            "Please make sure you have enough free disk space, then open ZClassic again."));
+        return;
     }
     main->logger->write("Downloading to " + filename);
     qDebug() << "Downloading " << url << " to " << filename;
     
     QNetworkRequest request(url);
     request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+    // P1-5: a stalled socket should fail fast and retry instead of hanging forever.
+    // NOTE: in Qt 5.15 setTransferTimeout lives on QNetworkRequest / QNetworkAccessManager,
+    // NOT on QNetworkReply, so it is set here on the request before get().
+    request.setTransferTimeout(30000);
     currentDownload = client->get(request);
     downloadTime.start();
     
     // Download Progress
     QObject::connect(currentDownload, &QNetworkReply::downloadProgress, [=] (auto done, auto total) {
         // calculate the download speed
-        double speed = done * 1000.0 / downloadTime.elapsed();
+        double speed = done * 1000.0 / (downloadTime.elapsed() > 0 ? downloadTime.elapsed() : 1);
         QString unit;
-        if (speed < 1024) {
-            unit = "bytes/sec";
-        } else if (speed < 1024*1024) {
-            speed /= 1024;
-            unit = "kB/s";
+        double dispSpeed = speed;
+        if (dispSpeed < 1024) {
+            unit = " bytes/sec";
+        } else if (dispSpeed < 1024*1024) {
+            dispSpeed /= 1024;
+            unit = " kB/s";
         } else {
-            speed /= 1024*1024;
-            unit = "MB/s";
+            dispSpeed /= 1024*1024;
+            unit = " MB/s";
         }
+
+        // P1-2: aggregate, friendly progress. Drive the real 0-100 bar off this
+        // file's percentage, and show file X of N plus an ETA for the current file.
+        QString eta;
+        if (total > 0 && speed > 1) {
+            int secsLeft = (int)((total - done) / speed);
+            if (secsLeft > 90)
+                eta = QObject::tr(", about ") % QString::number(secsLeft / 60) % QObject::tr(" min left");
+            else if (secsLeft > 0)
+                eta = QObject::tr(", about ") % QString::number(secsLeft) % QObject::tr(" sec left");
+        }
+        if (total > 0)
+            this->setBarPercent((int)(done * 100 / total));
 
         this->showInformation(
-            QObject::tr("Downloading ") % filename % (filesRemaining > 1 ? " ( +" % QString::number(filesRemaining)  % QObject::tr(" more remaining )") : QString("")),
-            QString::number(done/1024/1024, 'f', 0) % QObject::tr("MB of ") % QString::number(total/1024/1024, 'f', 0) + QObject::tr("MB at ") % QString::number(speed, 'f', 2) % unit);
+            QObject::tr("Step 1 of 3: Getting the security files ready…"),
+            QObject::tr("File ") % QString::number(fileNumber) % QObject::tr(" of ") % QString::number(totalFiles)
+                % " — "
+                % QString::number(done/1024.0/1024.0, 'f', 0) % QObject::tr(" MB of ")
+                % (total > 0 ? QString::number(total/1024.0/1024.0, 'f', 0) : QObject::tr("?")) % QObject::tr(" MB at ")
+                % QString::number(dispSpeed, 'f', 1) % unit % eta);
     });
     
-    // Download Finished
-    QObject::connect(currentDownload, &QNetworkReply::finished, [=] () {
-        // Rename file
-        main->logger->write("Finished downloading " + filename);
-        currentOutput->rename(QDir(paramsDir).filePath(filename));
-
-        currentOutput->close();
-        currentDownload->deleteLater();
-        currentOutput->deleteLater();
-
-        if (currentDownload->error()) {
-            main->logger->write("Downloading " + filename + " failed");
-            this->showError(QObject::tr("Downloading ") + filename + QObject::tr(" failed. Please check the help site for more info"));                
-        } else {
-            doNextDownload(cb);
-        }
-    });
-
     // Download new data available. 
     QObject::connect(currentDownload, &QNetworkReply::readyRead, [=] () {
-        currentOutput->write(currentDownload->readAll());
+        if (currentOutput)
+            currentOutput->write(currentDownload->readAll());
     });    
+
+    // Download Finished
+    QObject::connect(currentDownload, &QNetworkReply::finished, [=] () {
+        bool failed = (currentDownload->error() != QNetworkReply::NoError);
+
+        if (currentOutput) {
+            currentOutput->close();
+        }
+        currentDownload->deleteLater();
+
+        if (failed) {
+            main->logger->write("Downloading " + filename + " failed: " + currentDownload->errorString());
+            // Drop the partial file so a retry starts clean.
+            if (currentOutput) {
+                currentOutput->remove();
+                currentOutput->deleteLater();
+                currentOutput = nullptr;
+            }
+
+            // P1-2/P1-5: auto-retry the same file a few times, then offer a Retry button
+            // instead of a dead end.
+            if (ezRetryCount < 3) {
+                ezRetryCount++;
+                main->logger->write(QString("Auto-retrying download (attempt %1)").arg(ezRetryCount));
+                this->showInformation(QObject::tr("Step 1 of 3: Getting the security files ready…"),
+                                      QObject::tr("Connection hiccup — retrying…"));
+                QTimer::singleShot(1500, [=]() { this->doNextDownload(cb); });
+            } else {
+                this->offerRetry(QObject::tr("The setup files couldn't finish downloading.\n\n"
+                    "This is almost always a temporary internet problem."), cb);
+            }
+            return;
+        }
+
+        // Success: rename the .part into place and move on.
+        main->logger->write("Finished downloading " + filename);
+        if (currentOutput) {
+            currentOutput->rename(QDir(paramsDir).filePath(filename));
+            currentOutput->deleteLater();
+            currentOutput = nullptr;
+        }
+        ezRetryCount = 0;
+        downloadQueue->dequeue();
+        doNextDownload(cb);
+    });
 }
 
 bool ConnectionLoader::startEmbeddedZClassicd() {
@@ -315,7 +432,11 @@ bool ConnectionLoader::startEmbeddedZClassicd() {
     if (ezclassicd != nullptr) {
         if (ezclassicd->state() == QProcess::NotRunning) {
             if (!processStdErrOutput.isEmpty()) {
-                QMessageBox::critical(main, QObject::tr("zclassicd error"), "zclassicd said: " + processStdErrOutput, 
+                main->logger->write("node stderr: " + processStdErrOutput);
+                QMessageBox::critical(main, QObject::tr("ZClassic"),
+                                      QObject::tr("Your wallet had trouble starting up.\n\n"
+                                      "Please open ZClassic again. If it keeps happening, make sure your "
+                                      "security software isn't blocking it and that you have free disk space."),
                                       QMessageBox::Ok);
             }
             return false;
@@ -394,8 +515,8 @@ void ConnectionLoader::doManualConnect() {
     auto connection = makeConnection(config);
     refreshZClassicdState(connection, [=] () {
         QString explanation = QString()
-                % QObject::tr("Could not connect to zclassicd configured in settings.\n\n" 
-                "Please set the host/port and user/password in the Edit->Settings menu.");
+                % QObject::tr("ZClassic couldn't connect to the node in your settings.\n\n" 
+                "Please check the address and sign-in details under Edit → Settings.");
 
         showError(explanation);
         doRPCSetConnection(nullptr);
@@ -455,8 +576,9 @@ void ConnectionLoader::refreshZClassicdState(Connection* connection, std::functi
             } else if (err == QNetworkReply::NetworkError::AuthenticationRequiredError) {
                 main->logger->write("Authentication failed");
                 QString explanation = QString() % 
-                        QObject::tr("Authentication failed. The username / password you specified was "
-                        "not accepted by zclassicd. Try changing it in the Edit->Settings menu");
+                        QObject::tr("ZClassic couldn't sign in to its node.\n\n"
+                        "The saved username or password wasn't accepted. "
+                        "You can correct it under Edit → Settings.");
 
                 this->showError(explanation);
             } else if (err == QNetworkReply::NetworkError::InternalServerError && 
@@ -470,7 +592,7 @@ void ConnectionLoader::refreshZClassicdState(Connection* connection, std::functi
                     if (dots > 3)
                         dots = 0;
                 }
-                this->showInformation(QObject::tr("Your ZClassic node is starting up. Please wait."), status);
+                this->showInformation(QObject::tr("Step 2 of 3: Starting your wallet…"), status);
                 main->logger->write("Waiting for zclassicd to come online.");
                 // Refresh after one second
                 QTimer::singleShot(1000, [=]() { this->refreshZClassicdState(connection, refused); });
@@ -481,6 +603,11 @@ void ConnectionLoader::refreshZClassicdState(Connection* connection, std::functi
 
 // Update the UI with the status
 void ConnectionLoader::showInformation(QString info, QString detail) {
+    // Once we reach the syncing phase, drop the now-stale onboarding card so it
+    // doesn't contradict the live status; the progress bar carries on.
+    if (info.contains(QObject::tr("Step 3")) && ezCard && ezCard->isVisible())
+        ezCard->setVisible(false);
+
     static int rescanCount = 0;
     if (detail.toLower().startsWith("rescan")) {
         rescanCount++;
@@ -652,6 +779,55 @@ std::shared_ptr<ConnectionConfig> ConnectionLoader::loadFromSettings() {
 
 
 
+
+// P1-7: refuse to start a ~1.7GB download / heavy sync when the disk is nearly full.
+bool ConnectionLoader::ensureEnoughDiskSpace(const QString& path) {
+    QStorageInfo storage(path);
+    if (!storage.isValid() || !storage.isReady()) {
+        // Can't tell -- don't block the user on an unknown.
+        main->logger->write("Disk space check skipped (storage not ready) for " + path);
+        return true;
+    }
+
+    const qint64 needed = (qint64)3 * 1024 * 1024 * 1024;   // ~3 GB
+    qint64 avail = storage.bytesAvailable();
+    main->logger->write(QString("Free space at %1: %2 MB").arg(path).arg(avail / 1024 / 1024));
+
+    if (avail < needed) {
+        QString human = QString::number(avail / 1024.0 / 1024.0 / 1024.0, 'f', 1);
+        this->showError(QObject::tr("Not enough free disk space.\n\n"
+            "ZClassic needs about 3 GB free to finish setting up, but only %1 GB is available. "
+            "Please free up some space and open ZClassic again.").arg(human));
+        return false;
+    }
+    return true;
+}
+
+// P1-2: switch the onboarding bar from busy/indeterminate to a real 0-100 reading.
+void ConnectionLoader::setBarPercent(int pct) {
+    if (!ezProgress) return;
+    if (pct < 0) pct = 0;
+    if (pct > 100) pct = 100;
+    if (ezProgress->maximum() == 0)
+        ezProgress->setRange(0, 100);
+    ezProgress->setValue(pct);
+}
+
+// P1-2: instead of a dead-end error on a failed download, let the user try again.
+void ConnectionLoader::offerRetry(QString explanation, std::function<void(void)> cb) {
+    auto choice = QMessageBox::warning(main, QObject::tr("ZClassic"),
+        explanation % "\n\n" % QObject::tr("Would you like to try again?"),
+        QMessageBox::Retry | QMessageBox::Cancel, QMessageBox::Retry);
+
+    if (choice == QMessageBox::Retry) {
+        ezRetryCount = 0;
+        main->logger->write("User chose to retry param download");
+        QTimer::singleShot(100, [=]() { this->doNextDownload(cb); });
+    } else {
+        this->showError(QObject::tr("Setup was stopped.\n\n"
+            "You can open ZClassic again whenever you're ready to finish setting up."));
+    }
+}
 
 /***********************************************************************************
  *  Connection Class

--- a/src/connection.h
+++ b/src/connection.h
@@ -65,6 +65,7 @@ private:
     void doRPCSetConnection(Connection* conn);
 
     QProcess*               ezclassicd  = nullptr;
+    QElapsedTimer           ezWarmupTimer;   // measures embedded-node startup/warmup time
 
     QDialog*                d;
     Ui_ConnectionDialog*    connD;

--- a/src/connection.h
+++ b/src/connection.h
@@ -56,7 +56,10 @@ private:
     bool verifyParams();
     void downloadParams(std::function<void(void)> cb);
     void doNextDownload(std::function<void(void)> cb);
-    bool startEmbeddedZClassicd();
+    // P2-1: optional one-shot extra args (e.g. "-reindex-chainstate") are passed
+    // ONLY to the next launch and are NOT persisted into zclassic.conf, so a
+    // repair can never loop forever.
+    bool startEmbeddedZClassicd(const QStringList& extraArgs = QStringList());
 
     void refreshZClassicdState(Connection* connection, std::function<void(void)> refused);
 
@@ -69,6 +72,24 @@ private:
     bool ensureEnoughDiskSpace(const QString& path);
     void setBarPercent(int pct);
     void offerRetry(QString explanation, std::function<void(void)> cb);
+
+    // P2-1: corruption failsafe. When the embedded node dies DURING warmup
+    // (before the RPC connection is established) we classify the failure from
+    // its stderr + debug.log tail and, if it looks like a corrupt/partway block
+    // or chainstate database, offer a safe, staged repair ladder. NONE of these
+    // paths ever touch wallet.dat except to read+copy it as a backup.
+    bool        ezNodeQuitDuringStartup = false;  // node exited before RPC came up
+    bool        ezRepairOffered         = false;  // repair dialog already shown this run
+    QString     ezStdErr;                          // accumulated node stderr this run
+    QString     ezDataDir;                         // datadir holding blocks/chainstate/debug.log/wallet.dat
+
+    void    handleStartupFailure();                       // detect + classify + route
+    bool    looksLikeDbCorruption(const QString& text);   // marker scan
+    QString readDebugLogTail(int maxBytes = 16384);        // read-only tail of debug.log
+    void    offerCorruptionRepair();                       // staged repair ladder dialog
+    void    relaunchForRepair(const QStringList& extraArgs);  // backup wallet, then relaunch once
+    bool    backupWalletForRepair();                       // read+copy wallet.dat; never writes it
+    QDir    resolveDataSubdir();                            // datadir root, or testnet3/ when it holds the chain
 
     QProcess*               ezclassicd  = nullptr;
     QElapsedTimer           ezWarmupTimer;   // measures embedded-node startup/warmup time

--- a/src/connection.h
+++ b/src/connection.h
@@ -8,6 +8,7 @@
 using json = nlohmann::json;
 
 class RPC;
+class QProgressBar;
 
 enum ConnectionType {
     DetectedConfExternalZClassicD = 1,
@@ -64,8 +65,17 @@ private:
 
     void doRPCSetConnection(Connection* conn);
 
+    // P1-2 / P1-7 idiotproof-onboarding helpers
+    bool ensureEnoughDiskSpace(const QString& path);
+    void setBarPercent(int pct);
+    void offerRetry(QString explanation, std::function<void(void)> cb);
+
     QProcess*               ezclassicd  = nullptr;
     QElapsedTimer           ezWarmupTimer;   // measures embedded-node startup/warmup time
+
+    QLabel*                 ezCard      = nullptr;   // one-time onboarding explainer card
+    QProgressBar*           ezProgress  = nullptr;   // onboarding progress indicator
+    int                     ezRetryCount = 0;        // consecutive param-download retries
 
     QDialog*                d;
     Ui_ConnectionDialog*    connD;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,6 +1,8 @@
 #include "mainwindow.h"
 #include "addressbook.h"
 #include "ui_mainwindow.h"
+#include <QProgressBar>
+#include <QElapsedTimer>
 #include "ui_mobileappconnector.h"
 #include "ui_addressbook.h"
 #include "ui_zboard.h"
@@ -428,6 +430,119 @@ void MainWindow::setupStatusBar() {
     ui->statusBar->addPermanentWidget(statusIcon);
 }
 
+// P0-6: prominent, non-technical-friendly sync banner on the Balance/main tab.
+// Built in C++ (rather than hand-editing the .ui XML) so the insertion is
+// mechanically safe: gridLayout_2 holds exactly one item (horizontalLayout_5),
+// which we move to row 1 while the banner takes row 0.
+void MainWindow::setupSyncBanner() {
+    syncBanner = new QWidget(ui->tab);
+    auto* bannerLayout = new QHBoxLayout(syncBanner);
+    bannerLayout->setContentsMargins(8, 6, 8, 6);
+    bannerLayout->setSpacing(10);
+
+    syncStatusLabel = new QLabel(syncBanner);
+    syncStatusLabel->setWordWrap(true);
+    syncStatusLabel->setText(tr("Connecting to your ZClassic node…"));
+    QFont f = syncStatusLabel->font();
+    f.setBold(true);
+    syncStatusLabel->setFont(f);
+
+    syncProgressBar = new QProgressBar(syncBanner);
+    syncProgressBar->setRange(0, 100);
+    syncProgressBar->setValue(0);
+    syncProgressBar->setTextVisible(true);
+    syncProgressBar->setMinimumWidth(180);
+    syncProgressBar->setMaximumWidth(300);
+    syncProgressBar->setVisible(false);
+
+    bannerLayout->addWidget(syncStatusLabel, 1);
+    bannerLayout->addWidget(syncProgressBar, 0);
+
+    // Move the existing balances content (horizontalLayout_5) down to row 1 and
+    // place the banner on row 0. takeAt(0) is safe: gridLayout_2 has one item.
+    auto* grid = ui->gridLayout_2;
+    QLayoutItem* existing = grid->takeAt(0);
+    grid->addWidget(syncBanner, 0, 0, 1, 1);
+    if (existing && existing->layout()) {
+        grid->addItem(existing, 1, 0, 1, 1);
+    } else if (existing) {
+        // Fallback (shouldn't happen): re-add whatever we took.
+        grid->addItem(existing, 1, 0, 1, 1);
+    }
+    grid->setRowStretch(0, 0);
+    grid->setRowStretch(1, 1);
+
+    // Start in the neutral "connecting" state.
+    setSyncStatusConnecting();
+}
+
+// P0-6: called from rpc.cpp's getblockchaininfo poll on every refresh.
+void MainWindow::setSyncStatus(bool isSyncing, int blockNumber, int estimatedHeight, double progress) {
+    if (syncBanner == nullptr) return;
+
+    if (!isSyncing) {
+        // Fully caught up: unmistakable green "ready" state.
+        syncEtaStarted = false;
+        syncProgressBar->setVisible(false);
+        syncStatusLabel->setText(tr("✓ Synced — Ready to use"));
+        syncBanner->setStyleSheet("QWidget { background-color: #1f7a1f; } QLabel { color: white; }");
+        return;
+    }
+
+    // Syncing: show a progress bar and an estimated time remaining.
+    int pct = (int) (progress * 100.0);
+    if (pct < 0)   pct = 0;
+    if (pct > 100) pct = 100;
+    syncProgressBar->setVisible(true);
+    syncProgressBar->setValue(pct);
+
+    QString etaText;
+    if (estimatedHeight > 0 && blockNumber > 0) {
+        if (!syncEtaStarted) {
+            syncEtaStarted = true;
+            syncEtaStartBlock = blockNumber;
+            syncEtaTimer.restart();
+        } else {
+            qint64 elapsedMs = syncEtaTimer.elapsed();
+            int    blocksDone = blockNumber - syncEtaStartBlock;
+            if (elapsedMs > 2000 && blocksDone > 0) {
+                double blocksPerSec = (double) blocksDone / (elapsedMs / 1000.0);
+                int    remaining    = estimatedHeight - blockNumber;
+                if (blocksPerSec > 0.0 && remaining > 0) {
+                    qint64 secsLeft = (qint64) (remaining / blocksPerSec);
+                    QString human;
+                    if (secsLeft >= 3600)
+                        human = tr("about %1h %2m").arg(secsLeft / 3600).arg((secsLeft % 3600) / 60);
+                    else if (secsLeft >= 60)
+                        human = tr("about %1m").arg(secsLeft / 60);
+                    else
+                        human = tr("less than a minute");
+                    etaText = QString(" • ") % tr("ETA %1").arg(human);
+                }
+            }
+        }
+    }
+
+    QString heightText;
+    if (estimatedHeight > 0) {
+        heightText = QString(" • ") % tr("block %1 / ~%2")
+            .arg(QString::number(blockNumber), QString::number(estimatedHeight));
+    }
+
+    syncStatusLabel->setText(tr("Syncing blockchain… %1%").arg(pct) % heightText % etaText);
+    syncBanner->setStyleSheet("QWidget { background-color: #d9822b; } QLabel { color: white; }");
+}
+
+// P0-6: called from rpc.cpp's noConnection() so the user sees a clear,
+// non-alarming "connecting" state instead of a blank/stuck UI.
+void MainWindow::setSyncStatusConnecting() {
+    if (syncBanner == nullptr) return;
+    syncEtaStarted = false;
+    syncProgressBar->setVisible(false);
+    syncStatusLabel->setText(tr("Connecting to your ZClassic node…"));
+    syncBanner->setStyleSheet("QWidget { background-color: #555555; } QLabel { color: white; }");
+}
+
 void MainWindow::setupSettingsModal() {    
     // Set up File -> Settings action
     QObject::connect(ui->actionSettings, &QAction::triggered, [=]() {
@@ -772,6 +887,117 @@ void MainWindow::balancesReady() {
         pendingURIPayment = "";
     }
 
+    // P0-2: now that the wallet is live, make sure the user has a backup of
+    // wallet.dat. This is the single most important fund-safety step because
+    // the wallet is file-based and has NO seed-phrase recovery.
+    promptWalletBackup();
+}
+
+// P0-2: First-run / until-backed-up fund-safety prompt.
+//
+// The ZClassic wallet is wallet.dat FILE-based: there is NO BIP39 seed phrase.
+// If the user loses wallet.dat (disk failure, reinstall, lost laptop) and has
+// no backup, the coins are gone forever. This prompt nags on every launch
+// until the user backs up (file copy) or exports their private keys, then it
+// is silenced permanently via the persisted "options/walletbackedup" flag.
+//
+// It is modal/blocking but ALWAYS dismissible ("Maybe later") so it can never
+// become an un-closable trap.
+void MainWindow::promptWalletBackup() {
+    // Already backed up at some point? Never nag again.
+    if (QSettings().value("options/walletbackedup", false).toBool())
+        return;
+
+    // We need a live connection to know where wallet.dat lives / to copy it.
+    if (!rpc || !rpc->getConnection())
+        return;
+
+    QMessageBox box(this);
+    box.setWindowTitle(tr("Back up your wallet"));
+    box.setIcon(QMessageBox::Warning);
+    box.setText(tr("Protect your coins — back up your wallet now."));
+    box.setInformativeText(tr(
+        "Your ZClassic is stored in a single file on this computer called "
+        "<b>wallet.dat</b>. There is <b>no seed phrase / recovery phrase</b> for this wallet.<br><br>"
+        "If this computer is lost, reset, or its disk fails and you have no backup, "
+        "<b>your coins are gone forever and cannot be recovered by anyone</b>.<br><br>"
+        "Make a backup now and keep a copy somewhere safe (a USB stick or another "
+        "computer). You can:<br>"
+        "&nbsp;&nbsp;• Save a copy of the wallet.dat file, or<br>"
+        "&nbsp;&nbsp;• Export your private keys to a text file.<br><br>"
+        "Keep your backup private — anyone who has it can spend your coins."));
+
+    QPushButton* backupBtn = box.addButton(tr("Back Up Now"), QMessageBox::AcceptRole);
+    QPushButton* exportBtn = box.addButton(tr("Export Private Keys"), QMessageBox::ActionRole);
+    QPushButton* laterBtn  = box.addButton(tr("Maybe later"), QMessageBox::RejectRole);
+    box.setDefaultButton(backupBtn);
+
+    box.exec();
+    QAbstractButton* clicked = box.clickedButton();
+
+    if (clicked == backupBtn) {
+        // Copy wallet.dat to a user-chosen location. We mirror backupWalletDat()
+        // here (rather than calling it) so we can detect a SUCCESSFUL copy and
+        // only then mark the wallet as backed up.
+        QDir zclassicdir(rpc->getConnection()->config->zclassicDir);
+        QString backupDefaultName = "zclassic-wallet-backup-" +
+            QDateTime::currentDateTime().toString("yyyyMMdd") + ".dat";
+
+        if (Settings::getInstance()->isTestnet()) {
+            zclassicdir.cd("testnet3");
+            backupDefaultName = "testnet-" + backupDefaultName;
+        }
+
+        QFile wallet(zclassicdir.filePath("wallet.dat"));
+        if (!wallet.exists()) {
+            QMessageBox::critical(this, tr("No wallet.dat"),
+                tr("Couldn't find the wallet.dat on this computer") + "\n" +
+                tr("You need to back it up from the machine zclassicd is running on"),
+                QMessageBox::Ok);
+            return;
+        }
+
+        QUrl backupName = QFileDialog::getSaveFileUrl(this, tr("Backup wallet.dat"),
+            backupDefaultName, "Data file (*.dat)");
+        if (backupName.isEmpty())
+            return;  // User cancelled the save dialog: leave the flag unset so we nag again next launch.
+
+        if (wallet.copy(backupName.toLocalFile())) {
+            // Success: remember that the wallet has been backed up.
+            QSettings().setValue("options/walletbackedup", true);
+            QMessageBox::information(this, tr("Backup complete"),
+                tr("Your wallet backup was saved.\n\n"
+                   "Keep this file private and in a safe place. You can restore your "
+                   "coins later by copying it back into the wallet's data folder."),
+                QMessageBox::Ok);
+        } else {
+            QMessageBox::critical(this, tr("Couldn't backup"),
+                tr("Couldn't backup the wallet.dat file.") +
+                tr("You need to back it up manually."), QMessageBox::Ok);
+        }
+    } else if (clicked == exportBtn) {
+        // Reuse the existing private-key export dialog. The user saves the keys
+        // to a file from inside that dialog. Because that dialog's Save is
+        // optional and reports no status, we explicitly confirm the user
+        // actually saved before marking the wallet backed up -- otherwise we'd
+        // give a false sense of safety and never remind them again.
+        exportAllKeys();
+        auto saved = QMessageBox::question(this, tr("Did you save your keys?"),
+            tr("Did you save the file with your private keys somewhere safe?\n\n"
+               "Only choose Yes if you actually saved it — otherwise we'll remind "
+               "you to back up again next time."),
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        if (saved == QMessageBox::Yes)
+            QSettings().setValue("options/walletbackedup", true);
+    } else {
+        // "Maybe later" (or the dialog was closed): make the consequence explicit,
+        // but never block. The flag stays unset, so we nag again next launch.
+        QMessageBox::warning(this, tr("No backup yet"),
+            tr("You have not backed up your wallet.\n\n"
+               "Until you do, you risk losing all your coins if this computer is "
+               "lost or breaks. We'll remind you again next time you open the wallet."),
+            QMessageBox::Ok);
+    }
 }
 
 // Event filter for MacOS specific handling of payment URIs
@@ -921,7 +1147,10 @@ void MainWindow::importPrivKey() {
 
         // Show the dialog that keys will be imported. 
         QMessageBox::information(this,
-            "Imported", tr("The keys were imported. It may take several minutes to rescan the blockchain. Until then, functionality may be limited"),
+            tr("Importing keys"),
+            tr("Your keys are being imported and the wallet will now rescan the "
+               "blockchain. This can take several minutes — your balance will "
+               "update when it finishes. Please leave ZClassic open."),
             QMessageBox::Ok);
     }
 }
@@ -984,6 +1213,13 @@ void MainWindow::exportAllKeys() {
 
 void MainWindow::exportKeys(QString addr) {
     bool allKeys = addr.isEmpty() ? true : false;
+
+    // P1-6: private keys ARE the money — anyone who sees this text can spend your funds, so confirm intent first.
+    if (QMessageBox::warning(this, tr("Export Private Keys"),
+            tr("Anyone who has these private keys can spend all the funds in these addresses. Only export them if you are sure no one else can see your screen or the saved file."),
+            QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Cancel) != QMessageBox::Ok) {
+        return;
+    }
 
     QDialog d(this);
     Ui_PrivKey pui;
@@ -1062,6 +1298,9 @@ void MainWindow::exportKeys(QString addr) {
 
 void MainWindow::setupBalancesTab() {
     ui->unconfirmedWarning->setVisible(false);
+
+    // P0-6: build the prominent sync banner that sits above the balances.
+    setupSyncBanner();
 
     // Double click on balances table
     auto fnDoSendFrom = [=](const QString& addr, const QString& to = QString(), bool sendMax = false) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -4,6 +4,9 @@
 #include "precompiled.h"
 #include "logger.h"
 
+#include <QProgressBar>
+#include <QElapsedTimer>
+
 // Forward declare to break circular dependency.
 class RPC;
 class Settings;
@@ -64,6 +67,16 @@ public:
     QLabel*             loadingLabel;
     QWidget*            zclassicdtab;
 
+    // P0-6: prominent sync banner on the Balance/main tab. Called by rpc.cpp
+    // from the getblockchaininfo poll (setSyncStatus) and from noConnection
+    // (setSyncStatusConnecting) so a non-technical user always knows the state.
+    QWidget*            syncBanner       = nullptr;
+    QLabel*             syncStatusLabel  = nullptr;
+    QProgressBar*       syncProgressBar  = nullptr;
+
+    void setSyncStatus(bool isSyncing, int blockNumber, int estimatedHeight, double progress);
+    void setSyncStatusConnecting();
+
     Logger*      logger;
 
     void doClose();
@@ -80,6 +93,12 @@ private:
     void setupTurnstileDialog();
     void setupSettingsModal();
     void setupStatusBar();
+    void setupSyncBanner();
+
+    // P0-6: state used to estimate a sync ETA from observed block rate.
+    QElapsedTimer       syncEtaTimer;
+    bool                syncEtaStarted = false;
+    int                 syncEtaStartBlock = 0;
 
     void removeExtraAddresses();
 
@@ -114,6 +133,10 @@ private:
     void exportKeys(QString addr = "");
     void backupWalletDat();
     void exportTransactions();
+
+    // P0-2: first-run fund-safety prompt. Nags (once per launch) to back up
+    // wallet.dat until the user has backed up, then never nags again.
+    void promptWalletBackup();
 
     void doImport(QList<QString>* keys);
 

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -384,6 +384,9 @@ void RPC::noConnection() {
     main->statusLabel->setToolTip("");
     main->ui->statusBar->showMessage(QObject::tr("No Connection"), 1000);
 
+    // P0-6: reflect the lost connection in the main-tab sync banner.
+    main->setSyncStatusConnecting();
+
     // Clear balances table.
     QMap<QString, double> emptyBalances;
     QList<UnspentOutput>  emptyOutputs;
@@ -624,6 +627,10 @@ void RPC::getInfoThenRefresh(bool force) {
 
             Settings::getInstance()->setSyncing(isSyncing);
             Settings::getInstance()->setBlockNumber(blockNumber);
+
+            // P0-6: update the prominent sync banner on the Balance/main tab so
+            // a non-technical user always sees Syncing %/ETA vs. "Synced — Ready".
+            main->setSyncStatus(isSyncing, blockNumber, estimatedheight, progress);
 
             // Update zclassicd tab if it exists
             if (ezclassicd) {

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -86,7 +86,10 @@ void RPC::setConnection(Connection* c) {
     delete conn;
     this->conn = c;
 
-    ui->statusBar->showMessage("Ready!");
+    // Don't claim "Ready!" here -- we've only just connected to the node; it may
+    // still be syncing. The real status (Syncing %/Connected) is set by the
+    // getblockchaininfo poll a moment later.
+    ui->statusBar->showMessage(QObject::tr("Connected — checking blockchain…"));
 
     // See if we need to remove the reindex/rescan flags from the zclassic.conf file
     auto zclassicConfLocation = Settings::getInstance()->getZClassicdConfLocation();
@@ -599,12 +602,24 @@ void RPC::getInfoThenRefresh(bool force) {
 
         conn->doRPCIgnoreError(payload, [=](const json& reply) {
             auto progress    = reply["verificationprogress"].get<double>();
-            bool isSyncing   = progress < 0.9999; // 99.99%
             int  blockNumber = reply["blocks"].get<json::number_unsigned_t>();
 
             int estimatedheight = 0;
             if (reply.find("estimatedheight") != reply.end()) {
                 estimatedheight = reply["estimatedheight"].get<json::number_unsigned_t>();
+            }
+
+            // Prefer a block-height comparison: it is accurate and actually reaches
+            // 100% when synced (verificationprogress is a coarse tx-count heuristic
+            // that historically pinned near 96%). Fall back to verificationprogress
+            // only if the node did not report an estimated height.
+            bool isSyncing;
+            if (estimatedheight > 0) {
+                progress = (double)blockNumber / (double)estimatedheight;
+                if (progress > 1.0) progress = 1.0;
+                isSyncing = blockNumber < (estimatedheight - 2); // within 2 blocks = synced
+            } else {
+                isSyncing = progress < 0.9999;
             }
 
             Settings::getInstance()->setSyncing(isSyncing);

--- a/src/sendtab.cpp
+++ b/src/sendtab.cpp
@@ -553,8 +553,15 @@ bool MainWindow::confirmTx(Tx tx) {
     int row = 0;
     double totalSpending = 0;
 
+    // P1-3: a send becomes PUBLIC (loses privacy) the moment any of the funds land on a
+    // transparent t-address, because the amount is then visible on the public blockchain.
+    bool isPublicTx = false;
+
     for (int i=0; i < tx.toAddrs.size(); i++) {
         auto toAddr = tx.toAddrs[i];
+
+        if (Settings::isTAddress(toAddr.addr))
+            isPublicTx = true;
 
         // Add new Address widgets instead of the same one.
         {
@@ -643,6 +650,9 @@ bool MainWindow::confirmTx(Tx tx) {
     // No peers warning
     confirm.nopeersWarning->setVisible(Settings::getInstance()->getPeers() == 0);
 
+    // P1-3: public (de-shield) warning
+    confirm.publicWarning->setVisible(isPublicTx);
+
     // And FromAddress in the confirm dialog 
     confirm.sendFrom->setText(fnSplitAddressForWrap(tx.fromAddr));
     QString tooltip = tr("Current balance      : ") +
@@ -664,6 +674,18 @@ bool MainWindow::confirmTx(Tx tx) {
 // Send button clicked
 void MainWindow::sendButton() {
     Tx tx = createTxFromSendPage();
+
+    // Still-syncing acknowledgement gate: during sync the balance/UTXO set is
+    // incomplete, so a send can silently fail. Make the user explicitly accept
+    // that risk (default No) instead of relying only on the soft confirm label.
+    if (Settings::getInstance()->isSyncing()) {
+        auto res = QMessageBox::warning(this, tr("Wallet still syncing"),
+            tr("Your wallet is still catching up with the network, so your balance "
+               "may be incomplete and this transaction could fail.\n\nSend anyway?"),
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        if (res != QMessageBox::Yes)
+            return;
+    }
 
     QString error = doSendTxValidations(tx);
     if (!error.isEmpty()) {
@@ -715,6 +737,25 @@ QString MainWindow::doSendTxValidations(Tx tx) {
         }
     }
 
+    // Insufficient-funds guard: catch an overspend up front with a friendly
+    // message instead of letting it fail minutes later with a cryptic node
+    // error. Only enforced when the balance is reliable (not mid-sync), and
+    // null-guarded since balances may not be loaded yet during early startup.
+    if (!Settings::getInstance()->isSyncing()) {
+        auto bals = rpc ? rpc->getAllBalances() : nullptr;
+        if (bals && bals->contains(tx.fromAddr)) {
+            double balance = bals->value(tx.fromAddr);
+            double total   = tx.fee;
+            for (auto toAddr : tx.toAddrs)
+                total += toAddr.amount;
+            if (total > balance) {
+                return tr("Not enough funds. You're trying to send %1 (including the fee), "
+                          "but this address only holds %2.")
+                       .arg(Settings::getZCLDisplayFormat(total))
+                       .arg(Settings::getZCLDisplayFormat(balance));
+            }
+        }
+    }
 
     return QString();
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,6 +1,138 @@
 #include "mainwindow.h"
 #include "settings.h"
 
+#include <QCryptographicHash>
+#include <QVector>
+#include <cstring>
+
+// ============================================================================
+// Address checksum validation helpers (file-local).
+//
+// The point of these is to catch TYPOS so funds are never sent to a mistyped
+// address. We verify checksum INTEGRITY only -- we deliberately do NOT
+// hardcode a version-byte whitelist, so no legitimate ZClassic address can be
+// rejected just because we didn't anticipate its prefix.
+// ============================================================================
+namespace {
+
+// ----- base58check (transparent t-addrs and Sprout zc/ztn addrs) -----------
+static const char* B58_ALPHABET =
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+// Decode a base58 string into raw bytes. Returns false on any non-base58
+// character. Handles leading '1's as leading zero bytes.
+static bool base58Decode(const QString& str, QByteArray& out) {
+    // Build a big-endian byte vector by repeated base-58 -> base-256 conversion.
+    QByteArray b256; // accumulates the big number, big-endian
+    for (QChar qc : str) {
+        // Reject non-ASCII and characters outside the alphabet.
+        if (qc.unicode() > 127)
+            return false;
+        const char* p = strchr(B58_ALPHABET, qc.toLatin1());
+        if (p == nullptr || *p == '\0')   // '\0' guard: strchr matches terminator
+            return false;
+        int carry = static_cast<int>(p - B58_ALPHABET);
+
+        for (int i = b256.size() - 1; i >= 0; i--) {
+            carry += 58 * static_cast<unsigned char>(b256.at(i));
+            b256[i] = static_cast<char>(carry & 0xFF);
+            carry >>= 8;
+        }
+        while (carry > 0) {
+            b256.prepend(static_cast<char>(carry & 0xFF));
+            carry >>= 8;
+        }
+    }
+
+    // Each leading '1' in the input is a leading zero byte.
+    QByteArray leadingZeros;
+    for (QChar qc : str) {
+        if (qc == QChar('1'))
+            leadingZeros.append('\0');
+        else
+            break;
+    }
+
+    out = leadingZeros + b256;
+    return true;
+}
+
+// Verify a base58check string: last 4 bytes must equal the first 4 bytes of
+// the double-SHA256 of the preceding payload.
+static bool base58CheckValid(const QString& str) {
+    QByteArray raw;
+    if (!base58Decode(str, raw))
+        return false;
+
+    // Need at least 1 payload byte + 4 checksum bytes.
+    if (raw.size() < 5)
+        return false;
+
+    QByteArray payload  = raw.left(raw.size() - 4);
+    QByteArray checksum = raw.right(4);
+
+    QByteArray h1 = QCryptographicHash::hash(payload, QCryptographicHash::Sha256);
+    QByteArray h2 = QCryptographicHash::hash(h1,      QCryptographicHash::Sha256);
+
+    return h2.left(4) == checksum;
+}
+
+// ----- bech32 (Sapling zs / ztestsapling addrs) -----------------------------
+static const char* BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+static quint32 bech32Polymod(const QVector<int>& values) {
+    static const quint32 GEN[5] = {
+        0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3
+    };
+    quint32 chk = 1;
+    for (int v : values) {
+        quint32 b = chk >> 25;
+        chk = ((chk & 0x1ffffff) << 5) ^ static_cast<quint32>(v);
+        for (int i = 0; i < 5; i++) {
+            if ((b >> i) & 1)
+                chk ^= GEN[i];
+        }
+    }
+    return chk;
+}
+
+// Verify a bech32 string's checksum (the original BIP173 polymod == 1 form,
+// which is what Zcash/ZClassic Sapling addresses use).
+static bool bech32ChecksumValid(const QString& addr) {
+    // bech32 must be entirely lower-case or entirely upper-case (no mixing).
+    QString lower = addr.toLower();
+    QString upper = addr.toUpper();
+    if (addr != lower && addr != upper)
+        return false;
+    QString s = lower;
+
+    int sep = s.lastIndexOf(QChar('1'));
+    // HRP must be non-empty; data part (incl. 6-char checksum) must be present.
+    if (sep < 1 || sep + 7 > s.size())
+        return false;
+
+    QVector<int> values;
+    // Expand the human-readable part.
+    const QString hrp = s.left(sep);
+    for (QChar c : hrp)
+        values.append(c.unicode() >> 5);
+    values.append(0);
+    for (QChar c : hrp)
+        values.append(c.unicode() & 31);
+
+    // Append the data part (everything after the separator).
+    for (int i = sep + 1; i < s.size(); i++) {
+        const char* p = strchr(BECH32_CHARSET, s.at(i).toLatin1());
+        if (p == nullptr || *p == '\0')
+            return false;
+        values.append(static_cast<int>(p - BECH32_CHARSET));
+    }
+
+    return bech32Polymod(values) == 1;
+}
+
+} // anonymous namespace
+
 Settings* Settings::instance = nullptr;
 
 Settings* Settings::init() {    
@@ -133,8 +265,18 @@ void Settings::setAllowCustomFees(bool allow) {
     QSettings().setValue("options/customfees", allow);
 }
 
+bool Settings::isWalletBackedUp() {
+    // Load from the QT Settings. Defaults to false so a brand-new wallet is
+    // treated as un-backed-up until the user actually confirms a backup.
+    return QSettings().value("options/walletbackedup", false).toBool();
+}
+
+void Settings::setWalletBackedUp(bool backedUp) {
+    QSettings().setValue("options/walletbackedup", backedUp);
+}
+
 bool Settings::getSaveZtxs() {
-    // Load from the QT Settings. 
+    // Load from the QT Settings.
     return QSettings().value("options/savesenttx", true).toBool();
 }
 
@@ -280,13 +422,29 @@ QString Settings::getZboardAddr() {
 }
 
 bool Settings::isValidAddress(QString addr) {
-    QRegExp zcexp("^z[a-z0-9]{94}$",  Qt::CaseInsensitive);
-    QRegExp zsexp("^z[a-z0-9]{77}$",  Qt::CaseInsensitive);
-    QRegExp ztsexp("^ztestsapling[a-z0-9]{76}", Qt::CaseInsensitive);
-    QRegExp texp("^t[a-z0-9]{34}$", Qt::CaseInsensitive);
+    // Structural pre-filter (same shapes the wallet has always accepted). This
+    // bounds length/charset cheaply; the checksum gate below then verifies the
+    // address is actually self-consistent so typos are caught.
+    QRegExp zcexp("^z[a-z0-9]{94}$",  Qt::CaseInsensitive);   // Sprout  (zc.. / ztn..)
+    QRegExp zsexp("^z[a-z0-9]{77}$",  Qt::CaseInsensitive);   // Sapling (zs1..)
+    QRegExp ztsexp("^ztestsapling[a-z0-9]{76}", Qt::CaseInsensitive); // testnet Sapling
+    QRegExp texp("^t[a-z0-9]{34}$", Qt::CaseInsensitive);     // transparent (t1.. / t3..)
 
-    return  zcexp.exactMatch(addr)  || texp.exactMatch(addr) || 
-            ztsexp.exactMatch(addr) || zsexp.exactMatch(addr);
+    // Sapling addresses are bech32 -> verify the bech32 polymod checksum.
+    // Note: the testnet-Sapling regex is a prefix match (matches the broader
+    // Sprout shape too), so test bech32 first and fall through on failure.
+    if (addr.startsWith("zs", Qt::CaseInsensitive) || addr.startsWith("ztestsapling", Qt::CaseInsensitive)) {
+        if (zsexp.exactMatch(addr) || ztsexp.exactMatch(addr))
+            return bech32ChecksumValid(addr);
+        return false;
+    }
+
+    // Transparent and Sprout addresses are base58check -> verify the 4-byte
+    // double-SHA256 checksum.
+    if (texp.exactMatch(addr) || zcexp.exactMatch(addr))
+        return base58CheckValid(addr);
+
+    return false;
 }
 
 const QString Settings::labelRegExp("[a-zA-Z0-9\\-_]{0,40}");

--- a/src/settings.h
+++ b/src/settings.h
@@ -46,6 +46,9 @@ public:
     bool    getSaveZtxs();
     void    setSaveZtxs(bool save);
 
+    bool    isWalletBackedUp();
+    void    setWalletBackedUp(bool backedUp);
+
     bool    getAutoShield();
     void    setAutoShield(bool allow);
 


### PR DESCRIPTION
Makes the ZClassic GUI robust and idiotproof for non-technical users, across three commits.

**1. Patient warmup + accurate sync** (d3b6000)
- No more false "couldn't start the embedded zclassicd" during the normal ~1min warmup
- Block-based sync %, clamped to 100% (kills the 96%/premature-"Ready" confusion)

**2. Onboarding, sync banner, backup prompt, send & param safety** (4cf7cd2)
- Onboarding card + main-tab sync banner (Connecting / Syncing %+ETA / Synced)
- First-funds wallet.dat backup prompt (file-based wallet, no seed phrase) — flag set only on a verified copy / explicit "I saved my keys"
- Checksum-validating address field (base58check + bech32) — catches typo'd sends; unit-tested to accept valid t1/t3/zs1 and reject typos
- Param-download integrity (only promote .part on success), 30s timeout, disk precheck
- De-shield "this is PUBLIC" warning, key-export warning, insufficient-funds block, still-syncing "Send anyway?" gate, clearer import message

**3. Corruption failsafe — guided, key-safe recovery** (cba8f71)
- Detects the embedded node exiting during startup; reads stderr + a read-only tail of debug.log
- Classifies: corrupt/partway DB → staged repair ladder; disk-full / "already running" → targeted message (never a futile reindex)
- Repair ladder backs up wallet.dat FIRST, then `-reindex-chainstate` → `-reindex` → re-download; one-shot flags; attempt-capped
- **Hard invariant:** no path ever deletes/renames/writes wallet.dat — only a read-only backup copy

Qt-only, no new deps. Compile-verified on Linux. UI look/feel to be validated on Mac + Windows hardware.