### PR TITLE
wallet(send): fix auto-shield change — integer zatoshis + exclude coinbase

### DIFF
--- a/src/balancestablemodel.h
+++ b/src/balancestablemodel.h
@@ -6,9 +6,15 @@
 struct UnspentOutput {
     QString address;
     QString txid;
-    QString amount;    
+    QString amount;
     int     confirmations;
     bool    spendable;
+    // listunspent "generated": true for a coinbase UTXO. z_sendmany cannot spend
+    // coinbase to a transparent output or alongside change (consensus rule
+    // bad-txns-coinbase-spend-has-transparent-outputs), so the auto-shield change
+    // basis must EXCLUDE these. C++14 default member init keeps this an aggregate,
+    // so existing brace-initializers without the field still compile (coinbase=false).
+    bool    coinbase = false;
 };
 
 class BalancesTableModel : public QAbstractTableModel

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -276,11 +276,12 @@ private:
     // ONLY ever returns a real Sapling address (never degrades to Sprout/transparent).
     QString findUnusedSaplingChangeAddr(const Tx& tx);
     QString createSaplingAddressSync();
-    // MAJOR-2: CONFIRMED (confirmations>0), spendable balance of `addr`, summed from
-    // the wallet's UTXO set. z_sendmany spends only confirmed notes, so this is the
-    // correct basis for the auto-shield change amount (getAllBalances() includes
-    // unconfirmed). Null-safe (returns 0 if UTXOs aren't loaded yet).
-    double  confirmedSpendableBalance(const QString& addr);
+    // CONFIRMED (confirmations>0), spendable balance of `addr` in integer zatoshis,
+    // summed from the wallet's UTXO set -- the correct, drift-free basis for the
+    // auto-shield change amount (z_sendmany spends only confirmed notes; getAllBalances()
+    // includes unconfirmed). includeCoinbase=false additionally excludes coinbase UTXOs to
+    // match the daemon's has-change input set. Null-safe (returns 0 if UTXOs not loaded).
+    qint64  confirmedSpendableZat(const QString& addr, bool includeCoinbase);
     // PRIV-27 one-shot: surface the Sprout-recipient "change stays transparent"
     // constraint at most once per run instead of nagging on every keystroke/build.
     bool sproutChangeWarned = false;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -33,15 +33,18 @@ struct Tx {
     QList<ToFields> toAddrs;
     double          fee;
 
-    // Snapshot-race guard. Stamped ONLY by createTxFromSendPage()'s auto-shield branch
-    // when it builds an explicit Sapling change output; the pre-send gate
-    // (verifyAutoShieldUnchanged) re-polls the from-addr and ABORTS if the live eligible
-    // set no longer matches, so a surplus that confirmed during the confirm dwell cannot
-    // escape as PUBLIC transparent change. Default-off keeps every other send (z-from,
-    // auto-shield off, Sprout recipient, coinbase-only "shield everything") byte-identical:
-    // the gate early-returns true and never re-polls. C++14 default member initializers
-    // keep Tx an aggregate, so the positional Tx{from, to, fee} brace-inits still compile.
-    bool   autoShieldGuardActive = false;  // true only when an explicit Sapling change was built
+    // Snapshot-race guard. Stamped by createTxFromSendPage()'s auto-shield branch whenever
+    // the daemon could emit PUBLIC transparent change at send time -- i.e. an explicit
+    // Sapling change output was built (autoShieldFullConsume=false), OR the send consumes the
+    // whole confirmed balance with no change (autoShieldFullConsume=true). The pre-send gate
+    // (verifyAutoShieldUnchanged) re-polls and ABORTS if the relevant live total no longer
+    // matches what we sized against, so a surplus that confirms during the confirm dwell
+    // cannot escape as public change. Default-off keeps non-auto-shield sends (z-from, auto-
+    // shield off, Sprout recipient) byte-identical: the gate early-returns true, no re-poll.
+    // C++14 default member initializers keep Tx an aggregate, so the positional
+    // Tx{from, to, fee} brace-inits still compile.
+    bool   autoShieldGuardActive = false;  // re-verify before the irrevocable z_sendmany
+    bool   autoShieldFullConsume = false;  // true: no-change full balance spend (check total)
     qint64 builtEligibleZat      = 0;      // confirmedSpendableZat(fromAddr,false) at build time
     qint64 builtTargetZat        = 0;      // recipients (excl. change row) + fee, at build time
 };

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -32,6 +32,18 @@ struct Tx {
     QString         fromAddr;
     QList<ToFields> toAddrs;
     double          fee;
+
+    // Snapshot-race guard. Stamped ONLY by createTxFromSendPage()'s auto-shield branch
+    // when it builds an explicit Sapling change output; the pre-send gate
+    // (verifyAutoShieldUnchanged) re-polls the from-addr and ABORTS if the live eligible
+    // set no longer matches, so a surplus that confirmed during the confirm dwell cannot
+    // escape as PUBLIC transparent change. Default-off keeps every other send (z-from,
+    // auto-shield off, Sprout recipient, coinbase-only "shield everything") byte-identical:
+    // the gate early-returns true and never re-polls. C++14 default member initializers
+    // keep Tx an aggregate, so the positional Tx{from, to, fee} brace-inits still compile.
+    bool   autoShieldGuardActive = false;  // true only when an explicit Sapling change was built
+    qint64 builtEligibleZat      = 0;      // confirmedSpendableZat(fromAddr,false) at build time
+    qint64 builtTargetZat        = 0;      // recipients (excl. change row) + fee, at build time
 };
 
 // PRIV-11 / UX-12 — the four-way SendCategory enum + the pure free classifier
@@ -72,6 +84,9 @@ public:
     // drive the real confirm dialog, and seeds an empty RPC balances map so
     // confirmTx's rpc->getAllBalances() deref is safe without a live daemon.
     bool testConfirmTx(Tx tx)  { return confirmTx(tx); }
+    // Drive the REAL snapshot-race gate so the L1 race tests can assert it aborts on a
+    // diverging fresh snapshot (injected via RPC::testSetRepollUTXOs) and proceeds otherwise.
+    bool testVerifyAutoShield(const Tx& tx) { return verifyAutoShieldUnchanged(tx); }
     void testSeedBalances();
     // Build the send-page Tx through the REAL createTxFromSendPage() path so the
     // L1 fail-open tests (PRIV-10) exercise the actual production routing.
@@ -282,6 +297,20 @@ private:
     // includes unconfirmed). includeCoinbase=false additionally excludes coinbase UTXOs to
     // match the daemon's has-change input set. Null-safe (returns 0 if UTXOs not loaded).
     qint64  confirmedSpendableZat(const QString& addr, bool includeCoinbase);
+
+    // Snapshot-race gate (SAFE-RACE). verifyAutoShieldUnchanged() is the LAST check before
+    // the irrevocable z_sendmany: for an auto-shield-change send it synchronously re-polls
+    // the from-addr's transparent UTXOs (repollFromAddrUtxos, mirroring
+    // createSaplingAddressSync's bounded pump) and ABORTS fail-closed if the live eligible
+    // non-coinbase total no longer matches what the change was sized against; for any other
+    // send it returns true immediately. Returns false => caller must NOT send.
+    enum class RepollResult { Refreshed, NoConnection, Timeout };
+    RepollResult repollFromAddrUtxos();
+    bool    verifyAutoShieldUnchanged(const Tx& tx);
+    // Reentrancy guard for the blocking re-poll pump (sibling of saplingSyncCreateInFlight),
+    // so a second sendButton click can't nest a second synchronous re-poll.
+    bool    autoShieldRepollInFlight = false;
+
     // PRIV-27 one-shot: surface the Sprout-recipient "change stays transparent"
     // constraint at most once per run instead of nagging on every keystroke/build.
     bool sproutChangeWarned = false;

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1214,6 +1214,55 @@ bool RPC::processUnspent(const json& reply, QMap<QString, double>* balancesMap, 
     return anyUnconfirmed;
 };
 
+// SAFE-RACE: keep the shielded-note rows from `oldUtxos` and replace the transparent rows
+// with `freshT`. A row is transparent iff Settings::isTAddress(address). Frees both inputs
+// and returns a new owned list. A transparent-only re-poll thus never drops the z-notes.
+QList<UnspentOutput>* RPC::mergeTransparentUnspent(QList<UnspentOutput>* oldUtxos,
+                                                   QList<UnspentOutput>* freshT) {
+    auto* merged = new QList<UnspentOutput>();
+    if (oldUtxos) {
+        for (const UnspentOutput& u : *oldUtxos)
+            if (!Settings::isTAddress(u.address))     // keep shielded notes as-is
+                merged->append(u);
+        delete oldUtxos;
+    }
+    if (freshT) {
+        merged->append(*freshT);
+        delete freshT;
+    }
+    return merged;
+}
+
+// SAFE-RACE: re-poll ONLY the transparent UTXOs and splice them into the cached `utxos`,
+// preserving the shielded-note rows. Invokes cb(true) once fresh data has landed; returns
+// false (and cb(false)) when it cannot fire so the caller fails closed. See
+// MainWindow::verifyAutoShieldUnchanged.
+bool RPC::repollTransparentUnspent(const std::function<void(bool)>& cb) {
+#ifdef ZCL_WIDGET_TEST
+    // TEST-ONLY SEAM: no daemon. If a fresh transparent set was injected, splice it in
+    // (preserving z rows) and fire the callback SYNCHRONOUSLY -- no pump, no connection.
+    if (testRepollUTXOs) {
+        utxos = mergeTransparentUnspent(utxos, testRepollUTXOs);   // takes ownership / frees inputs
+        testRepollUTXOs = nullptr;
+        cb(true);
+        return true;
+    }
+    cb(false);
+    return false;     // no seam installed -> caller fails closed
+#else
+    if (!conn) { cb(false); return false; }            // never null-deref getTransparentUnspent
+    getTransparentUnspent([this, cb](json reply) {
+        auto* freshT       = new QList<UnspentOutput>();
+        auto* throwawayBals = new QMap<QString, double>();
+        processUnspent(reply, throwawayBals, freshT);  // reuse the exact parser (sets coinbase)
+        delete throwawayBals;
+        utxos = mergeTransparentUnspent(utxos, freshT);
+        cb(true);
+    });
+    return true;
+#endif
+}
+
 void RPC::refreshBalances() {    
     if  (conn == nullptr) 
         return noConnection();

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -1198,10 +1198,16 @@ bool RPC::processUnspent(const json& reply, QMap<QString, double>* balancesMap, 
             anyUnconfirmed = true;
         }
 
+        // "generated" marks a coinbase UTXO (transparent listunspent only; z_listunspent
+        // omits it). The auto-shield change basis must exclude coinbase, since z_sendmany
+        // refuses to spend it to a transparent output or alongside change. (find()/end()
+        // is used rather than contains() -- the bundled nlohmann::json 3.3 predates it.)
+        bool coinbase = it.find("generated") != it.end() && it["generated"].get<json::boolean_t>();
+
         newUtxos->push_back(
             UnspentOutput{ qsAddr, QString::fromStdString(it["txid"]),
                             Settings::getDecimalString(it["amount"].get<json::number_float_t>()),
-                            (int)confirmations, it["spendable"].get<json::boolean_t>() });
+                            (int)confirmations, it["spendable"].get<json::boolean_t>(), coinbase });
 
         (*balancesMap)[qsAddr] = (*balancesMap)[qsAddr] + it["amount"].get<json::number_float_t>();
     }

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -87,6 +87,10 @@ public:
     // Install the wallet's UTXO set so confirmedSpendableZat() (the confirmed,
     // non-coinbase change basis) can be driven without a daemon.
     void testSetUTXOs(QList<UnspentOutput>* u)      { delete utxos; utxos = u; }
+    // SAFE-RACE: install the "fresh" transparent set the NEXT repollTransparentUnspent()
+    // splices in (simulates a UTXO landing/leaving at the from-addr during the confirm
+    // dwell). One-shot: consumed by the re-poll. Never present in the shipped app build.
+    void testSetRepollUTXOs(QList<UnspentOutput>* u) { delete testRepollUTXOs; testRepollUTXOs = u; }
     // MAJOR-3: control the result of the next newZaddr(true) sync-create. A non-empty
     // string makes the create SUCCEED (returns that address); leaving it empty makes
     // the create FAIL (callback never fires), exercising the fail-closed path. The
@@ -103,6 +107,13 @@ public:
     void testFireNotifyPush() { onNotifyPush(); }
     bool testNotifyDebounceActive() const { return notifyDebounce && notifyDebounce->isActive(); }
 #endif
+
+    // SAFE-RACE: synchronously-driven re-poll of ONLY the transparent UTXOs, spliced into
+    // the cached `utxos` WITHOUT dropping the shielded-note rows. Fires the async
+    // listunspent (production) or applies an injected test set, and invokes cb(true) once
+    // fresh data has landed. Returns false (and cb(false)) when it could not fire (no
+    // connection / no test seam), so the caller fails closed. See verifyAutoShieldUnchanged.
+    bool repollTransparentUnspent(const std::function<void(bool)>& cb);
 
     void newZaddr(bool sapling, const std::function<void(json)>& cb);
     void newTaddr(const std::function<void(json)>& cb);
@@ -174,6 +185,12 @@ private:
     void refreshReceivedZTrans(QList<QString> zaddresses);
 
     bool processUnspent     (const json& reply, QMap<QString, double>* newBalances, QList<UnspentOutput>* newUtxos);
+    // SAFE-RACE: build a new owned list = the shielded-note rows kept from `oldUtxos`
+    // (classified by !Settings::isTAddress) + every row of `freshT` (the re-polled
+    // transparent set). Frees both inputs. Used by repollTransparentUnspent so a
+    // transparent-only re-poll never drops the wallet's z-notes.
+    QList<UnspentOutput>* mergeTransparentUnspent(QList<UnspentOutput>* oldUtxos,
+                                                  QList<UnspentOutput>* freshT);
     void updateUI           (bool anyUnconfirmed);
 
     void getInfoThenRefresh(bool force);
@@ -325,6 +342,9 @@ private:
     // (one-shot). Empty => the sync-create fails (fail-closed path). Never present
     // in the shipped app build.
     QString                     testNextZaddrResult;
+    // SAFE-RACE backing store: the transparent set the next repollTransparentUnspent()
+    // splices in (one-shot). nullptr => the re-poll cannot fire (fail-closed).
+    QList<UnspentOutput>*       testRepollUTXOs = nullptr;
 #endif
 };
 

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -84,8 +84,8 @@ public:
     void testSetBalances(QMap<QString, double>* b) { delete allBalances; allBalances = b; }
     void testSetZAddresses(QList<QString>* z)       { delete zaddresses; zaddresses = z; }
     void testSetTAddresses(QList<QString>* t)       { delete taddresses; taddresses = t; }
-    // MAJOR-2: install the wallet's UTXO set so confirmedSpendableBalance() (the
-    // confirmed-only change basis) can be driven without a daemon.
+    // Install the wallet's UTXO set so confirmedSpendableZat() (the confirmed,
+    // non-coinbase change basis) can be driven without a daemon.
     void testSetUTXOs(QList<UnspentOutput>* u)      { delete utxos; utxos = u; }
     // MAJOR-3: control the result of the next newZaddr(true) sync-create. A non-empty
     // string makes the create SUCCEED (returns that address); leaving it empty makes

--- a/src/sendtab.cpp
+++ b/src/sendtab.cpp
@@ -604,12 +604,18 @@ Tx MainWindow::createTxFromSendPage() {
             return Tx();   // invalid: empty fromAddr -> sendButton aborts the send
         }
 
+        // NOTE: z_sendmany does not pin inputs, so the no-leak reasoning below holds for
+        // the UTXO snapshot we polled (the steady state). If a t-UTXO confirms to the
+        // from-addr between this poll and the deferred send, the daemon re-selects against
+        // the larger live set and can emit the surplus as PUBLIC change. Closing that race
+        // (re-poll immediately before send, or daemon-side input pinning) is a separate
+        // follow-up; this computation still makes the common case strictly better.
         const qint64 changeZat = eligibleZat - targetZat;
         if (changeZat > 0) {
             // There is non-coinbase change to shield. Route it to a Sapling z-address;
             // the extra output keeps the send multi-output, so the daemon stays on its
-            // non-coinbase selection path and consumes the eligible set exactly --
-            // residual 0, no public transparent change.
+            // non-coinbase selection path and (against the polled snapshot) consumes the
+            // eligible set exactly -- residual 0, no public transparent change.
             QString changeAddr = findUnusedSaplingChangeAddr(tx);
 
             // No existing usable Sapling address -> create one NOW. Blocking RPC, but only
@@ -634,10 +640,12 @@ Tx MainWindow::createTxFromSendPage() {
         }
         // changeZat <= 0: the send consumes all eligible non-coinbase funds (and, for a
         // single z-recipient "shield everything", possibly coinbase too). We add NO change
-        // output: a non-positive change is not a real output, and the daemon never emits
-        // transparent change in this shape -- it fully shields to the lone z-recipient
-        // (change 0) or rejects the send outright, so it can never silently leak. (A
-        // coinbase-only address shielded via "Send max" lands here and succeeds.)
+        // output: a non-positive change is not a real output. Against the snapshot we
+        // polled, the daemon emits no transparent change in this shape -- it fully shields
+        // to the lone z-recipient (change 0) or rejects the send outright. (A coinbase-only
+        // address shielded via "Send max" lands here and succeeds.) The snapshot-race
+        // caveat noted above applies: a UTXO confirming before the deferred send can still
+        // surface surplus public change until the race is closed.
     }
 
     return tx;

--- a/src/sendtab.cpp
+++ b/src/sendtab.cpp
@@ -604,12 +604,13 @@ Tx MainWindow::createTxFromSendPage() {
             return Tx();   // invalid: empty fromAddr -> sendButton aborts the send
         }
 
-        // NOTE: z_sendmany does not pin inputs, so the no-leak reasoning below holds for
-        // the UTXO snapshot we polled (the steady state). If a t-UTXO confirms to the
-        // from-addr between this poll and the deferred send, the daemon re-selects against
-        // the larger live set and can emit the surplus as PUBLIC change. Closing that race
-        // (re-poll immediately before send, or daemon-side input pinning) is a separate
-        // follow-up; this computation still makes the common case strictly better.
+        // NOTE: z_sendmany does not pin inputs, so the no-leak reasoning below is sized
+        // against the UTXO snapshot polled HERE. The pre-send gate verifyAutoShieldUnchanged()
+        // re-polls and ABORTS if this exact eligible set changes before the deferred send, so
+        // a t-UTXO confirming during the confirm dwell can no longer turn into public change.
+        // That shrinks but does not fully close the TOCTOU (a UTXO can still confirm between
+        // the gate's re-poll and the daemon's own selection); the complete fix is daemon-side
+        // input pinning.
         const qint64 changeZat = eligibleZat - targetZat;
         if (changeZat > 0) {
             // There is non-coinbase change to shield. Route it to a Sapling z-address;
@@ -637,15 +638,23 @@ Tx MainWindow::createTxFromSendPage() {
             QString changeMemo = tr("Change from ") + tx.fromAddr;
             tx.toAddrs.push_back(ToFields{ changeAddr, (double)changeZat / 1e8,
                                            changeMemo, changeMemo.toUtf8().toHex() });
+
+            // SAFE-RACE: stamp the basis this change was sized against. The pre-send gate
+            // (verifyAutoShieldUnchanged) re-polls and ABORTS if eligibleZat no longer
+            // matches at send time -- closing the window where a t-UTXO confirms during the
+            // confirm dwell and the daemon emits the surplus as public transparent change.
+            tx.autoShieldGuardActive = true;
+            tx.builtEligibleZat      = eligibleZat;
+            tx.builtTargetZat        = targetZat;
         }
         // changeZat <= 0: the send consumes all eligible non-coinbase funds (and, for a
         // single z-recipient "shield everything", possibly coinbase too). We add NO change
-        // output: a non-positive change is not a real output. Against the snapshot we
-        // polled, the daemon emits no transparent change in this shape -- it fully shields
-        // to the lone z-recipient (change 0) or rejects the send outright. (A coinbase-only
-        // address shielded via "Send max" lands here and succeeds.) The snapshot-race
-        // caveat noted above applies: a UTXO confirming before the deferred send can still
-        // surface surplus public change until the race is closed.
+        // output: a non-positive change is not a real output, and the daemon emits no
+        // transparent change in this shape -- it fully shields to the lone z-recipient
+        // (change 0) or rejects the send outright. (A coinbase-only address shielded via
+        // "Send max" lands here and succeeds.) No change output is built, so the snapshot
+        // guard is left inactive here -- there is no shielded-change amount whose basis
+        // could go stale.
     }
 
     return tx;
@@ -668,6 +677,80 @@ qint64 MainWindow::confirmedSpendableZat(const QString& addr, bool includeCoinba
             sum += toZat(u.amount.toDouble());
     }
     return sum;
+}
+
+// SAFE-RACE: synchronously re-poll the from-addr's transparent UTXOs so the cached set
+// confirmedSpendableZat() reads reflects the daemon's LIVE selection at send time. Mirrors
+// createSaplingAddressSync()'s pattern exactly: a reentrancy guard with RAII clear, and a
+// bounded ExcludeUserInputEvents pump gated on an existing connection (so it cannot wedge a
+// send against a dead daemon). Returns Refreshed only when fresh data actually landed;
+// NoConnection / Timeout are treated by the caller as "cannot verify" -> fail closed.
+MainWindow::RepollResult MainWindow::repollFromAddrUtxos() {
+    if (!rpc)                       return RepollResult::NoConnection;
+    if (autoShieldRepollInFlight)   return RepollResult::NoConnection;   // refuse to nest
+    autoShieldRepollInFlight = true;
+    struct ClearGuard { bool* f; ~ClearGuard() { *f = false; } } _clr{ &autoShieldRepollInFlight };
+
+    bool done = false;
+    // Fire the re-poll. In production this returns immediately (the listunspent reply lands
+    // during the pump below); in the L1 test build the injected set is applied synchronously
+    // (done==true before the loop). false => could not fire (no connection / no test seam).
+    if (!rpc->repollTransparentUnspent([&](bool ok){ done = ok; }))
+        return RepollResult::NoConnection;
+
+    QElapsedTimer t; t.start();
+    while (!done && rpc->getConnection() && t.elapsed() < 8000)
+        QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents, 50);
+
+    if (done)
+        return RepollResult::Refreshed;
+    return rpc->getConnection() ? RepollResult::Timeout : RepollResult::NoConnection;
+}
+
+// SAFE-RACE gate: the LAST check before the irrevocable z_sendmany. For any non-auto-shield
+// send the stamp is inactive -> returns true immediately (today's behavior, no re-poll). For
+// an auto-shield-change send it re-polls the from-addr and ABORTS fail-closed on ANY change
+// to the eligible non-coinbase total, so a surplus that confirmed during the confirm dwell
+// can never escape as PUBLIC transparent change. This shrinks the TOCTOU window from tens of
+// seconds (poll staleness + dwell) to one RPC round-trip; fully closing it needs daemon-side
+// input pinning (z_sendmany with a fixed input set), which is a separate, daemon-side change.
+bool MainWindow::verifyAutoShieldUnchanged(const Tx& tx) {
+    if (!tx.autoShieldGuardActive)
+        return true;                                   // no-op for non-auto-shield sends
+
+    const RepollResult r = repollFromAddrUtxos();
+    if (r != RepollResult::Refreshed) {                // could not verify -> FAIL CLOSED
+        QMessageBox::warning(this, tr("Could not verify balance"),
+            tr("Your balance could not be re-checked before sending, so for your privacy "
+               "the transaction was NOT sent. Please try again in a moment."),
+            QMessageBox::Ok);
+        return false;
+    }
+
+    const qint64 liveEligibleZat = confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/false);
+    if (liveEligibleZat == tx.builtEligibleZat)
+        return true;                                   // verified identical -> SAFE to send
+
+    // The eligible non-coinbase set moved during the dwell. A GROWN set would let the daemon
+    // emit the surplus as PUBLIC change; a SHRUNK set would make it reject. Either way the
+    // stale change must NOT be sent. When the shortfall is purely mined (coinbase) funds,
+    // steer the user to the dedicated shield; otherwise show the generic notice.
+    const qint64 liveTotalZat = confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/true);
+    if (tx.builtTargetZat <= liveTotalZat && tx.builtTargetZat > liveEligibleZat) {
+        QMessageBox::warning(this, tr("Shield your mined funds first"),
+            tr("Part of this address's balance is newly mined (coinbase) coins, which can "
+               "only be moved by shielding the whole balance to a private address first. For "
+               "your privacy the transaction was NOT sent.\n\nUse \"Shield my public funds\" "
+               "to move them privately, then send again."),
+            QMessageBox::Ok);
+        return false;
+    }
+
+    QMessageBox::warning(this, tr("Balance changed — not sent"),
+        tr("Your balance for this address changed while you were confirming. For your "
+           "privacy the transaction was NOT sent. Please review the amounts and send again."),
+        QMessageBox::Ok);
+    return false;
 }
 
 // Find an existing Sapling z-address usable as the change sink: it must be a real
@@ -993,8 +1076,9 @@ bool MainWindow::confirmTx(Tx tx) {
                 return false;
         }
 
-        // Then delete the additional fields from the sendTo tab
-        removeExtraAddresses();
+        // NB: the send-page fields are cleared by sendButton() only AFTER the pre-send
+        // SAFE-RACE gate passes, so an abort there preserves the user's typed recipients
+        // for a one-click resend.
         return true;
     } else {
         return false;
@@ -1039,8 +1123,17 @@ void MainWindow::sendButton() {
     
     // Show a dialog to confirm the Tx
     if (confirmTx(tx)) {
+        // SAFE-RACE: re-poll + verify the from-addr's live eligible set immediately before
+        // the irrevocable z_sendmany. Fail-closed: on any divergence (or inability to
+        // verify) abort WITHOUT clearing the user's recipients, so they can review/resend.
+        if (!verifyAutoShieldUnchanged(tx))
+            return;
+
+        // Commit: clear the send page now that the Tx is actually being dispatched.
+        removeExtraAddresses();
+
         // And send the Tx
-        rpc->executeTransaction(tx, 
+        rpc->executeTransaction(tx,
             [=] (QString opid) {
                 ui->statusBar->showMessage(tr("Computing Tx: ") % opid);
             },

--- a/src/sendtab.cpp
+++ b/src/sendtab.cpp
@@ -667,15 +667,22 @@ Tx MainWindow::createTxFromSendPage() {
             tx.autoShieldGuardActive = true;
             tx.builtEligibleZat      = eligibleZat;
             tx.builtTargetZat        = targetZat;
+        } else if (targetZat == confirmedTotalZat) {
+            // Full-consume "shield everything": no change output -- the daemon consumes the
+            // WHOLE confirmed balance to the lone recipient (this is the single-Sapling-
+            // recipient shield, and the only changeZat<=0 case the band-abort lets through).
+            // Still race-prone: the recipient amount is frozen at build, so if ANY UTXO
+            // confirms at the from-addr during the dwell the live total exceeds it and the
+            // daemon can fund the frozen amount while leaving the surplus as PUBLIC change.
+            // Arm the guard to re-verify the live confirmed TOTAL is unchanged before sending.
+            tx.autoShieldGuardActive = true;
+            tx.autoShieldFullConsume = true;
+            tx.builtTargetZat        = targetZat;
         }
-        // changeZat <= 0: the send consumes all eligible non-coinbase funds (and, for a
-        // single z-recipient "shield everything", possibly coinbase too). We add NO change
-        // output: a non-positive change is not a real output, and the daemon emits no
-        // transparent change in this shape -- it fully shields to the lone z-recipient
-        // (change 0) or rejects the send outright. (A coinbase-only address shielded via
-        // "Send max" lands here and succeeds.) No change output is built, so the snapshot
-        // guard is left inactive here -- there is no shielded-change amount whose basis
-        // could go stale.
+        // Remaining changeZat <= 0 (targetZat < confirmedTotalZat): coinbase is present and
+        // the spend consumes exactly the non-coinbase eligible set, leaving coinbase behind.
+        // The daemon cannot fund a clean transparent-free spend in this shape (it rejects),
+        // so there is no surplus that could leak -- nothing to guard.
     }
 
     return tx;
@@ -712,18 +719,24 @@ MainWindow::RepollResult MainWindow::repollFromAddrUtxos() {
     autoShieldRepollInFlight = true;
     struct ClearGuard { bool* f; ~ClearGuard() { *f = false; } } _clr{ &autoShieldRepollInFlight };
 
-    bool done = false;
+    // `done` is a shared_ptr, NOT a stack bool captured by reference: the production
+    // listunspent reply is an async Qt slot that is NOT cancelled if our bounded pump times
+    // out. A by-ref capture would let that late reply write into this frame's destroyed stack
+    // (use-after-free). The shared_ptr keeps the flag alive for the late writer; on timeout we
+    // simply ignore it (the send aborts fail-closed) and the heap flag is freed when the last
+    // owner -- the outstanding callback -- runs.
+    auto done = std::make_shared<bool>(false);
     // Fire the re-poll. In production this returns immediately (the listunspent reply lands
     // during the pump below); in the L1 test build the injected set is applied synchronously
-    // (done==true before the loop). false => could not fire (no connection / no test seam).
-    if (!rpc->repollTransparentUnspent([&](bool ok){ done = ok; }))
+    // (*done==true before the loop). false => could not fire (no connection / no test seam).
+    if (!rpc->repollTransparentUnspent([done](bool ok){ *done = ok; }))
         return RepollResult::NoConnection;
 
     QElapsedTimer t; t.start();
-    while (!done && rpc->getConnection() && t.elapsed() < 8000)
+    while (!*done && rpc->getConnection() && t.elapsed() < 8000)
         QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents, 50);
 
-    if (done)
+    if (*done)
         return RepollResult::Refreshed;
     return rpc->getConnection() ? RepollResult::Timeout : RepollResult::NoConnection;
 }
@@ -744,6 +757,21 @@ bool MainWindow::verifyAutoShieldUnchanged(const Tx& tx) {
         QMessageBox::warning(this, tr("Could not verify balance"),
             tr("Your balance could not be re-checked before sending, so for your privacy "
                "the transaction was NOT sent. Please try again in a moment."),
+            QMessageBox::Ok);
+        return false;
+    }
+
+    // Full-consume (no change) send: safe only while the live confirmed TOTAL still equals
+    // exactly what we sized the spend against. Any new confirmation grows the total beyond
+    // the frozen amount -> the daemon can fund the amount and leave the surplus as PUBLIC
+    // change -> abort. (A coinbase-inclusive total is the right basis: the daemon draws the
+    // whole balance to the single z-recipient.)
+    if (tx.autoShieldFullConsume) {
+        if (confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/true) == tx.builtTargetZat)
+            return true;                               // still an exact full consume -> SAFE
+        QMessageBox::warning(this, tr("Balance changed — not sent"),
+            tr("Your balance for this address changed while you were confirming. For your "
+               "privacy the transaction was NOT sent. Please review the amounts and send again."),
             QMessageBox::Ok);
         return false;
     }

--- a/src/sendtab.cpp
+++ b/src/sendtab.cpp
@@ -604,6 +604,27 @@ Tx MainWindow::createTxFromSendPage() {
             return Tx();   // invalid: empty fromAddr -> sendButton aborts the send
         }
 
+        // Coinbase-only shortfall: the target fits the CONFIRMED total but NOT the
+        // non-coinbase eligible set, so the gap is mined (coinbase) money. A has-change
+        // send cannot spend coinbase (consensus: bad-txns-coinbase-spend-has-transparent-
+        // outputs), and a partial coinbase spend can't leave change either, so the daemon
+        // would reject cryptically. Steer the user to the dedicated shield instead.
+        // EXCEPTION: a single Sapling-recipient "shield everything" (target == the whole
+        // confirmed total) legitimately consumes coinbase to one zaddr with NO change --
+        // that path is allowed and handled by the changeZat<=0 branch below.
+        if (targetZat > eligibleZat
+                && !(tx.toAddrs.size() == 1
+                     && Settings::getInstance()->isSaplingAddress(tx.toAddrs[0].addr)
+                     && targetZat == confirmedTotalZat)) {
+            QMessageBox::warning(this, tr("Shield your mined funds first"),
+                tr("Part of this address's balance is newly mined (coinbase) coins, which "
+                   "can only be moved by shielding the whole balance to a private address "
+                   "first.\n\nUse \"Shield my public funds\" to move them privately, then "
+                   "send again."),
+                QMessageBox::Ok);
+            return Tx();   // invalid: empty fromAddr -> sendButton aborts the send
+        }
+
         // NOTE: z_sendmany does not pin inputs, so the no-leak reasoning below is sized
         // against the UTXO snapshot polled HERE. The pre-send gate verifyAutoShieldUnchanged()
         // re-polls and ABORTS if this exact eligible set changes before the deferred send, so

--- a/src/sendtab.cpp
+++ b/src/sendtab.cpp
@@ -10,6 +10,16 @@
 
 using json = nlohmann::json;
 
+// Convert a ZCL amount to integer zatoshis (1 ZCL = 1e8 zat). Wallet money is otherwise
+// carried as double; the auto-shield change must be computed in integer zatoshis so the
+// daemon's selected inputs are consumed EXACTLY (a fraction-of-a-zatoshi drift would make
+// z_sendmany either reject the tx or emit a public transparent-change output). The input
+// MUST be a <=8-decimal-place amount (the send/fee QRegExpValidators guarantee this), so
+// llround is exact and no half-zatoshi tie can occur for any value within MAX_MONEY.
+static inline qint64 toZat(double zcl) {
+    return static_cast<qint64>(llround(zcl * 1e8));
+}
+
 void MainWindow::setupSendTab() {
     // Create the validator for send to/amount fields
     auto amtValidator = new QRegExpValidator(QRegExp("[0-9]{0,8}\\.?[0-9]{0,8}"));    
@@ -503,7 +513,6 @@ Tx MainWindow::createTxFromSendPage() {
 
     // For each addr/amt in the sendTo tab
     int totalItems = ui->sendToWidgets->children().size() - 2;   // The last one is a spacer, so ignore that
-    double totalAmt = 0;
     bool   sproutRecipient = false;
     for (int i=0; i < totalItems; i++) {
         QString addr = ui->sendToWidgets->findChild<QLineEdit*>(QString("Address") % QString::number(i+1))->text().trimmed();
@@ -516,7 +525,6 @@ Tx MainWindow::createTxFromSendPage() {
         sendChangeToSapling = sendChangeToSapling && !Settings::getInstance()->isSproutAddress(addr);
 
         double  amt  = ui->sendToWidgets->findChild<QLineEdit*>(QString("Amount")  % QString::number(i+1))->text().trimmed().toDouble();
-        totalAmt += amt;
         QString memo = ui->sendToWidgets->findChild<QLabel*>(QString("MemoTxt")  % QString::number(i+1))->text().trimmed();
 
         tx.toAddrs.push_back( ToFields{addr, amt, memo, memo.toUtf8().toHex()} );
@@ -548,73 +556,108 @@ Tx MainWindow::createTxFromSendPage() {
     }
 
     // PRIV-10 / PRIV-19 / PRIV-28 — auto-shield, FAIL CLOSED on privacy. With
-    // auto-shield ON and a transparent from-addr, the change MUST be routed to a
-    // Sapling z-address. If a usable Sapling address exists we use it; if NONE
-    // exists we auto-create one (synchronous newZaddr(true) -- the last-resort
-    // fallback per DECISION #2; the common case is covered by
-    // ensureSaplingProvisioned() at first funding). If a Sapling change address
-    // STILL cannot be obtained, we do NOT proceed silently (z_sendmany would then
-    // route the change to a PUBLIC t-address) -- we ABORT the send and return an
-    // INVALID Tx. Fail CLOSED, never open.
+    // auto-shield ON and a transparent from-addr, any change MUST be routed to a
+    // Sapling z-address, never left on a PUBLIC t-address.
+    //
+    // The change amount is computed in INTEGER ZATOSHIS against the exact set of UTXOs
+    // z_sendmany will actually spend. Three daemon facts drive this (verified against
+    // the running daemon and its source); getting any of them wrong is what made the
+    // old double-arithmetic, coinbase-blind change either bounce with "insufficient
+    // funds" or leak a public transparent-change output:
+    //   1. z_sendmany has NO change-address parameter: taddr change ALWAYS flows to a
+    //      fresh keypool t-addr. The only way to shield it is to hand-build an explicit
+    //      Sapling output that consumes the spendable inputs EXACTLY (so the daemon's
+    //      own residual change is 0). Integer math removes the float drift that
+    //      otherwise left a few stray zatoshis as public change.
+    //   2. The daemon will NOT spend COINBASE UTXOs in a multi-output / has-change send
+    //      (consensus forbids coinbase->transparent; it spends coinbase only to a single
+    //      zaddr, whole value consumed). So the eligible set EXCLUDES coinbase, matching
+    //      the daemon's find_utxos(false) selection. (On ZClassic mainnet Overwinter is
+    //      active, so the daemon's t-input count cap is 0 and the eligible set is spent
+    //      in full with no truncation.)
+    //   3. z_sendmany spends ONLY confirmed notes (minconf 1), so unconfirmed UTXOs are
+    //      excluded -- a change based on getAllBalances() (which sums unconfirmed) would
+    //      be unfundable.
     if (Settings::getInstance()->getAutoShield() && sendChangeToSapling) {
-        QString changeAddr = findUnusedSaplingChangeAddr(tx);
+        // Eligible = CONFIRMED, spendable, NON-coinbase (what the daemon spends for a
+        // has-change send). The coinbase-inclusive total is the affordability ceiling:
+        // the daemon CAN spend coinbase, but only to a single zaddr with full
+        // consumption (no change), so it is fundable even when not "eligible" for change.
+        const qint64 eligibleZat       = confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/false);
+        const qint64 confirmedTotalZat = confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/true);
 
-        // No existing usable Sapling address -> create one NOW. This is a blocking
-        // RPC, but only on the (rare) first-ever send before any Sapling key exists.
-        if (changeAddr.isEmpty())
-            changeAddr = createSaplingAddressSync();
+        qint64 sendZat = 0;
+        for (const ToFields& t : tx.toAddrs)        // recipients only -- change not added yet
+            sendZat += toZat(t.amount);
+        const qint64 targetZat = sendZat + toZat(tx.fee);
 
-        if (changeAddr.isEmpty()) {
-            // MAJOR-1 fail-closed: we could not obtain a Sapling change sink, so the
-            // change would otherwise stay PUBLIC. Surface a blocking warning (mirrors
-            // shieldPublicFunds()'s style) and abort by returning an invalid Tx.
-            QMessageBox::warning(this, tr("Could not shield"),
-                tr("Could not shield — a Sapling change address could not be created, "
-                   "so your change would stay PUBLIC. Please try again in a moment."),
-                QMessageBox::Ok);
-            return Tx();   // invalid: empty fromAddr -> doSendTxValidations aborts the send
-        }
-
-        // MAJOR-2 funds-safety: base the change on the CONFIRMED, spendable balance of
-        // the from-addr. getAllBalances() SUMS unconfirmed (confirmations==0) utxos,
-        // but z_sendmany spends ONLY confirmed notes, so a change computed from the
-        // unconfirmed-inclusive total would emit an UNFUNDABLE change output and the
-        // daemon would reject the whole tx with insufficient-funds. If the confirmed
-        // spendable balance can't cover amount+fee, surface the existing not-enough-
-        // funds message UP FRONT and abort rather than emitting an unfundable change.
-        const double confirmed = confirmedSpendableBalance(tx.fromAddr);
-        if (confirmed < totalAmt + tx.fee) {
+        // Not enough CONFIRMED funds (coinbase included) to cover amount+fee. Surface the
+        // friendly message UP FRONT and abort rather than letting the daemon reject later.
+        if (targetZat > confirmedTotalZat) {
             QMessageBox::critical(this, tr("Transaction Error"),
                 tr("Not enough confirmed funds. You're trying to send %1 (including the "
                    "fee), but this address only holds %2 in confirmed, spendable funds. "
                    "Wait for your incoming funds to confirm and try again.")
-                   .arg(Settings::getZCLDisplayFormat(totalAmt + tx.fee))
-                   .arg(Settings::getZCLDisplayFormat(confirmed)),
+                   .arg(Settings::getZCLDisplayFormat((double)targetZat / 1e8))
+                   .arg(Settings::getZCLDisplayFormat((double)confirmedTotalZat / 1e8)),
                 QMessageBox::Ok);
-            return Tx();   // invalid: abort the send
+            return Tx();   // invalid: empty fromAddr -> sendButton aborts the send
         }
 
-        double change = confirmed - totalAmt - tx.fee;
-        if (Settings::getDecimalString(change) != "0") {
+        const qint64 changeZat = eligibleZat - targetZat;
+        if (changeZat > 0) {
+            // There is non-coinbase change to shield. Route it to a Sapling z-address;
+            // the extra output keeps the send multi-output, so the daemon stays on its
+            // non-coinbase selection path and consumes the eligible set exactly --
+            // residual 0, no public transparent change.
+            QString changeAddr = findUnusedSaplingChangeAddr(tx);
+
+            // No existing usable Sapling address -> create one NOW. Blocking RPC, but only
+            // on the (rare) first-ever send before any Sapling key exists; the common case
+            // is covered by ensureSaplingProvisioned() at first funding.
+            if (changeAddr.isEmpty())
+                changeAddr = createSaplingAddressSync();
+
+            if (changeAddr.isEmpty()) {
+                // Fail CLOSED: with no Sapling change sink the change would otherwise stay
+                // PUBLIC. Surface a blocking warning and abort with an invalid Tx.
+                QMessageBox::warning(this, tr("Could not shield"),
+                    tr("Could not shield — a Sapling change address could not be created, "
+                       "so your change would stay PUBLIC. Please try again in a moment."),
+                    QMessageBox::Ok);
+                return Tx();   // invalid: empty fromAddr -> sendButton aborts the send
+            }
+
             QString changeMemo = tr("Change from ") + tx.fromAddr;
-            tx.toAddrs.push_back(ToFields{ changeAddr, change, changeMemo, changeMemo.toUtf8().toHex() });
+            tx.toAddrs.push_back(ToFields{ changeAddr, (double)changeZat / 1e8,
+                                           changeMemo, changeMemo.toUtf8().toHex() });
         }
+        // changeZat <= 0: the send consumes all eligible non-coinbase funds (and, for a
+        // single z-recipient "shield everything", possibly coinbase too). We add NO change
+        // output: a non-positive change is not a real output, and the daemon never emits
+        // transparent change in this shape -- it fully shields to the lone z-recipient
+        // (change 0) or rejects the send outright, so it can never silently leak. (A
+        // coinbase-only address shielded via "Send max" lands here and succeeds.)
     }
 
     return tx;
 }
 
-// MAJOR-2 — sum the CONFIRMED (confirmations > 0), spendable UTXOs the GUI already
-// holds for `addr`. z_sendmany only spends confirmed notes, so this (not the
-// unconfirmed-inclusive getAllBalances() total) is the correct basis for the
-// auto-shield change amount. Null-safe: returns 0 if the UTXO set isn't loaded yet.
-double MainWindow::confirmedSpendableBalance(const QString& addr) {
+// Sum, in integer zatoshis, the CONFIRMED (confirmations > 0), spendable UTXOs the GUI
+// holds for `addr`. z_sendmany spends only confirmed notes, so this -- not the
+// unconfirmed-inclusive getAllBalances() total -- is the correct basis for the auto-shield
+// change. With includeCoinbase=false the result also excludes coinbase UTXOs, matching the
+// daemon's input set for a has-change (multi-output) send; includeCoinbase=true gives the
+// full confirmed-spendable ceiling (the daemon can still spend coinbase, but only to a
+// single zaddr with full consumption). Null-safe: returns 0 if the UTXO set isn't loaded.
+qint64 MainWindow::confirmedSpendableZat(const QString& addr, bool includeCoinbase) {
     if (!rpc || !rpc->getUTXOs())
-        return 0.0;
-    double sum = 0.0;
+        return 0;
+    qint64 sum = 0;
     for (const UnspentOutput& u : *rpc->getUTXOs()) {
-        if (u.address == addr && u.confirmations > 0 && u.spendable)
-            sum += u.amount.toDouble();
+        if (u.address == addr && u.confirmations > 0 && u.spendable
+                && (includeCoinbase || !u.coinbase))
+            sum += toZat(u.amount.toDouble());
     }
     return sum;
 }

--- a/tests/widget/tst_widget.cpp
+++ b/tests/widget/tst_widget.cpp
@@ -1028,8 +1028,11 @@ private slots:
             Tx tx = w->testCreateTxFromSendPage();
             QVERIFY2(!tx.fromAddr.isEmpty(), "exact-spend boundary must not abort");
             QCOMPARE(tx.toAddrs.size(), 1);                       // recipient only, NO change row
-            QVERIFY2(!tx.autoShieldGuardActive, "no change output => snapshot guard inactive");
-            QVERIFY2(w->testVerifyAutoShield(tx), "inactive guard => gate passes without re-poll");
+            // No change output, but the WHOLE confirmed balance is consumed -> the full-
+            // consume race guard arms: a UTXO confirming during the dwell would let the daemon
+            // leave a surplus as public change, so the gate re-verifies the total before send.
+            QVERIFY2(tx.autoShieldGuardActive && tx.autoShieldFullConsume,
+                     "exact full-consume (no change) must arm the full-consume race guard");
             settleAndDelete(w);
         }
         // (b) +1 zatoshi: eligible 3.00010001 -> a 1-zat change row is built and the gate arms.
@@ -1121,6 +1124,61 @@ private slots:
         QVERIFY2(tx.fromAddr.isEmpty(),
                  "partial coinbase spend (target in (eligible, total]) must abort with the "
                  "shield-mined-funds message, not silently build a doomed tx");
+
+        QSettings().remove("options/autoshield"); QSettings().sync();
+        settleAndDelete(w);
+    }
+
+    // ---- P16: full-consume "shield everything" is ALSO race-guarded ---------------------
+    // A single-Sapling-recipient shield of the whole (mixed coinbase + non-coinbase) balance
+    // builds NO change output, but is still leak-prone: if a non-coinbase UTXO confirms during
+    // the dwell the daemon can fund the frozen amount from non-coinbase alone and leave the
+    // surplus as PUBLIC change. The full-consume guard must arm and the gate must abort on a
+    // grown total (regression guard for the reviewer-found leak in the exemption path).
+    void p16_autoShieldFullConsumeRaceAborts() {
+        MainWindow* w = makeWindow(); auto* ui = w->ui;
+        const QString T = "t1HsdDMzmJfq4vc7T17XYjEkLMLvbgM1fCi";
+        const QString R = "zs1gv64eu0v2wx7raxqxlmj354y9ycznwaau9kduljzczxztvs4qcl00kn2sjxtejvrxnkucw5xx9u";
+
+        QSettings().setValue("options/autoshield", true); QSettings().sync();
+
+        // T holds 3 non-coinbase + 2 coinbase (total 5). Shield EVERYTHING to one zs recipient.
+        auto* bals = new QMap<QString, double>(); (*bals)[T] = 5.0;
+        w->getRPC()->testSetBalances(bals);
+        auto* utxos = new QList<UnspentOutput>();
+        utxos->append(UnspentOutput{ T, "nc0", "3.0", 10,  true, /*coinbase=*/false });
+        utxos->append(UnspentOutput{ T, "cb0", "2.0", 100, true, /*coinbase=*/true  });
+        w->getRPC()->testSetUTXOs(utxos);
+        auto* zs = new QList<QString>(); zs->append(R);
+        w->getRPC()->testSetZAddresses(zs);
+        ui->inputsCombo->clear(); ui->inputsCombo->addItem(T, 5.0); ui->inputsCombo->setCurrentIndex(0);
+        ui->Address1->setText(R); ui->Amount1->setText("4.9999");   // whole balance minus fee
+
+        Tx tx = w->testCreateTxFromSendPage();
+        QVERIFY2(tx.autoShieldGuardActive && tx.autoShieldFullConsume,
+                 "mixed full-consume shield must arm the full-consume race guard");
+        QCOMPARE(tx.toAddrs.size(), 1);                            // recipient only, NO change row
+        QVERIFY2(tx.builtTargetZat == (qint64)500000000, "full-consume target is the whole 5.0 ZCL");
+
+        // (a) total GREW (a 2.5 non-coinbase confirmed during the dwell) -> MUST abort.
+        {
+            auto* grown = new QList<UnspentOutput>();
+            grown->append(UnspentOutput{ T, "nc0", "3.0", 10,  true, false });
+            grown->append(UnspentOutput{ T, "cb0", "2.0", 100, true, true  });
+            grown->append(UnspentOutput{ T, "nc1", "2.5", 10,  true, false });
+            w->getRPC()->testSetRepollUTXOs(grown);
+            armModalDismisser();
+            QVERIFY2(!w->testVerifyAutoShield(tx),
+                     "a grown total in a full-consume send MUST abort (surplus would leak public change)");
+        }
+        // (b) total UNCHANGED -> the send still proceeds.
+        {
+            auto* same = new QList<UnspentOutput>();
+            same->append(UnspentOutput{ T, "nc0", "3.0", 10,  true, false });
+            same->append(UnspentOutput{ T, "cb0", "2.0", 100, true, true  });
+            w->getRPC()->testSetRepollUTXOs(same);
+            QVERIFY2(w->testVerifyAutoShield(tx), "an unchanged total => full-consume gate passes");
+        }
 
         QSettings().remove("options/autoshield"); QSettings().sync();
         settleAndDelete(w);

--- a/tests/widget/tst_widget.cpp
+++ b/tests/widget/tst_widget.cpp
@@ -878,6 +878,85 @@ private slots:
         settleAndDelete(w);
     }
 
+    // ---- P11: SAFE-RACE — the pre-send gate aborts when the eligible set diverges ------
+    // The auto-shield change is sized against the GUI's cached UTXO snapshot but the
+    // z_sendmany fires later (after the confirm dwell). If a confirmed non-coinbase t-UTXO
+    // lands at the from-addr in that gap, the daemon would re-select a larger live set and
+    // emit the surplus as PUBLIC transparent change. verifyAutoShieldUnchanged() re-polls
+    // (via the injected testSetRepollUTXOs seam) right before send and MUST abort on any
+    // divergence, proceed when unchanged, and be a no-op for non-auto-shield sends.
+    void p11_autoShieldGateAbortsOnSnapshotRace() {
+        const QString T  = "t1HsdDMzmJfq4vc7T17XYjEkLMLvbgM1fCi";
+        const QString ZS = "zs1gv64eu0v2wx7raxqxlmj354y9ycznwaau9kduljzczxztvs4qcl00kn2sjxtejvrxnkucw5xx9u";
+        const QString RECIP = "zs10m00rvkhfm4f7n23e4sxsx275r7ptnggx39ygl0vy46j9mdll5c97gl6dxgpk0njuptg2mn9w5s";
+
+        QSettings().setValue("options/autoshield", true);
+        QSettings().sync();
+
+        // Build an auto-shield-change Tx: T holds 5 ZCL (non-coinbase), send 3 to RECIP,
+        // change 1.9999 -> ZS. The build stamps autoShieldGuardActive + builtEligibleZat=5e8.
+        auto buildGuardedTx = [&](MainWindow* w) -> Tx {
+            auto* ui = w->ui;
+            auto* bals = new QMap<QString, double>(); (*bals)[T] = 5.0;
+            w->getRPC()->testSetBalances(bals);
+            auto* utxos = new QList<UnspentOutput>();
+            utxos->append(UnspentOutput{ T, "txid0", "5.0", 10, true, /*coinbase=*/false });
+            w->getRPC()->testSetUTXOs(utxos);
+            auto* zs = new QList<QString>(); zs->append(ZS);
+            w->getRPC()->testSetZAddresses(zs);
+            ui->inputsCombo->clear();
+            ui->inputsCombo->addItem(T, 5.0);
+            ui->inputsCombo->setCurrentIndex(0);
+            ui->Address1->setText(RECIP);
+            ui->Amount1->setText("3");
+            Tx tx = w->testCreateTxFromSendPage();
+            return tx;
+        };
+
+        // (a) DIVERGENCE: a 2 ZCL non-coinbase UTXO confirmed at T between build and send.
+        {
+            MainWindow* w = makeWindow();
+            Tx tx = buildGuardedTx(w);
+            QVERIFY2(tx.autoShieldGuardActive, "an explicit-change auto-shield send must arm the gate");
+            auto* fresh = new QList<UnspentOutput>();
+            fresh->append(UnspentOutput{ T, "txid0", "5.0", 10, true, false });
+            fresh->append(UnspentOutput{ T, "txid1", "2.0", 10, true, false });   // newly confirmed
+            w->getRPC()->testSetRepollUTXOs(fresh);
+            armModalDismisser();                          // the gate pops a blocking warning
+            QVERIFY2(!w->testVerifyAutoShield(tx),
+                     "a grown eligible set MUST abort the send (would leak surplus public change)");
+            settleAndDelete(w);
+        }
+
+        // (b) NO DIVERGENCE: the fresh re-poll matches the build snapshot -> send proceeds.
+        {
+            MainWindow* w = makeWindow();
+            Tx tx = buildGuardedTx(w);
+            auto* fresh = new QList<UnspentOutput>();
+            fresh->append(UnspentOutput{ T, "txid0", "5.0", 10, true, false });
+            w->getRPC()->testSetRepollUTXOs(fresh);
+            QVERIFY2(w->testVerifyAutoShield(tx),
+                     "an unchanged eligible set MUST let the send proceed");
+            settleAndDelete(w);
+        }
+
+        // (c) NO-OP: a non-auto-shield Tx (guard inactive) is never re-polled -> proceeds
+        // immediately. No re-poll seam is installed; if the gate wrongly re-polled it would
+        // hit the no-seam path and return false.
+        {
+            MainWindow* w = makeWindow();
+            Tx plain; plain.fromAddr = T; plain.fee = 0.0001;
+            ToFields f; f.addr = RECIP; f.amount = 1.0; plain.toAddrs.append(f);
+            QVERIFY2(!plain.autoShieldGuardActive, "a hand-built Tx must default to guard-inactive");
+            QVERIFY2(w->testVerifyAutoShield(plain),
+                     "a non-auto-shield send must pass the gate with no re-poll");
+            settleAndDelete(w);
+        }
+
+        QSettings().remove("options/autoshield");
+        QSettings().sync();
+    }
+
     // ---- P8: P0-2 — the at-rest "● Synced" pill ↔ loud banner swap ---------------
     // The headline visual-polish change: when fully caught up, the full-width
     // colored "Synced" bar is DEMOTED to a quiet inline pill (green lives on the

--- a/tests/widget/tst_widget.cpp
+++ b/tests/widget/tst_widget.cpp
@@ -957,6 +957,175 @@ private slots:
         QSettings().sync();
     }
 
+    // ---- P12: multi-recipient coinbase-only send aborts (daemon allows coinbase only to
+    // a SINGLE zaddr). The (eligible, total] coinbase-aware guard must catch it up front
+    // with the shield-mined-funds message instead of letting the daemon reject.
+    void p12_multiRecipientCoinbaseAborts() {
+        MainWindow* w = makeWindow();
+        auto* ui = w->ui;
+        const QString T  = "t1HsdDMzmJfq4vc7T17XYjEkLMLvbgM1fCi";
+        const QString R1 = "zs1gv64eu0v2wx7raxqxlmj354y9ycznwaau9kduljzczxztvs4qcl00kn2sjxtejvrxnkucw5xx9u";
+        const QString R2 = "zs10m00rvkhfm4f7n23e4sxsx275r7ptnggx39ygl0vy46j9mdll5c97gl6dxgpk0njuptg2mn9w5s";
+
+        QSettings().setValue("options/autoshield", true);
+        QSettings().sync();
+
+        auto* bals = new QMap<QString, double>(); (*bals)[T] = 4.0;
+        w->getRPC()->testSetBalances(bals);
+        auto* utxos = new QList<UnspentOutput>();
+        utxos->append(UnspentOutput{ T, "cb0", "2.0", 100, true, /*coinbase=*/true });
+        utxos->append(UnspentOutput{ T, "cb1", "2.0", 100, true, /*coinbase=*/true });
+        w->getRPC()->testSetUTXOs(utxos);
+        auto* zs = new QList<QString>(); zs->append(R1);
+        w->getRPC()->testSetZAddresses(zs);
+
+        ui->inputsCombo->clear();
+        ui->inputsCombo->addItem(T, 4.0);
+        ui->inputsCombo->setCurrentIndex(0);
+        ui->Address1->setText(R1);
+        ui->Amount1->setText("2");
+        ui->addAddressButton->click();                  // add a second recipient
+        auto* addr2 = ui->sendToWidgets->findChild<QLineEdit*>("Address2");
+        auto* amt2  = ui->sendToWidgets->findChild<QLineEdit*>("Amount2");
+        QVERIFY2(addr2 && amt2, "second recipient (Address2/Amount2) must be created");
+        addr2->setText(R2);
+        amt2->setText("1.9999");                        // total 3.9999 -> needs coinbase
+
+        armModalDismisser();
+        Tx tx = w->testCreateTxFromSendPage();
+        QVERIFY2(tx.fromAddr.isEmpty(),
+                 "multi-recipient coinbase-only send must abort (coinbase -> single zaddr only)");
+
+        QSettings().remove("options/autoshield");
+        QSettings().sync();
+        settleAndDelete(w);
+    }
+
+    // ---- P13: changeZat==0 boundary. Exactly amount+fee non-coinbase -> NO change output
+    // and the gate stays inactive; one zatoshi more -> a 1-zat Sapling change IS built and
+    // the gate arms. Pins the integer boundary the float code used to get wrong.
+    void p13_changeBoundaryExactZero() {
+        const QString T  = "t1HsdDMzmJfq4vc7T17XYjEkLMLvbgM1fCi";
+        const QString ZS = "zs1gv64eu0v2wx7raxqxlmj354y9ycznwaau9kduljzczxztvs4qcl00kn2sjxtejvrxnkucw5xx9u";
+        const QString R  = "zs10m00rvkhfm4f7n23e4sxsx275r7ptnggx39ygl0vy46j9mdll5c97gl6dxgpk0njuptg2mn9w5s";
+
+        QSettings().setValue("options/autoshield", true);
+        QSettings().sync();
+
+        // (a) Exact zero: eligible 3.0001 == amount 3 + fee 0.0001 -> no change, no guard.
+        {
+            MainWindow* w = makeWindow(); auto* ui = w->ui;
+            auto* bals = new QMap<QString, double>(); (*bals)[T] = 3.0001;
+            w->getRPC()->testSetBalances(bals);
+            auto* utxos = new QList<UnspentOutput>();
+            utxos->append(UnspentOutput{ T, "txid0", "3.0001", 10, true, false });
+            w->getRPC()->testSetUTXOs(utxos);
+            auto* zs = new QList<QString>(); zs->append(ZS);
+            w->getRPC()->testSetZAddresses(zs);
+            ui->inputsCombo->clear(); ui->inputsCombo->addItem(T, 3.0001); ui->inputsCombo->setCurrentIndex(0);
+            ui->Address1->setText(R); ui->Amount1->setText("3");
+
+            Tx tx = w->testCreateTxFromSendPage();
+            QVERIFY2(!tx.fromAddr.isEmpty(), "exact-spend boundary must not abort");
+            QCOMPARE(tx.toAddrs.size(), 1);                       // recipient only, NO change row
+            QVERIFY2(!tx.autoShieldGuardActive, "no change output => snapshot guard inactive");
+            QVERIFY2(w->testVerifyAutoShield(tx), "inactive guard => gate passes without re-poll");
+            settleAndDelete(w);
+        }
+        // (b) +1 zatoshi: eligible 3.00010001 -> a 1-zat change row is built and the gate arms.
+        {
+            MainWindow* w = makeWindow(); auto* ui = w->ui;
+            auto* bals = new QMap<QString, double>(); (*bals)[T] = 3.00010001;
+            w->getRPC()->testSetBalances(bals);
+            auto* utxos = new QList<UnspentOutput>();
+            utxos->append(UnspentOutput{ T, "txid0", "3.00010001", 10, true, false });
+            w->getRPC()->testSetUTXOs(utxos);
+            auto* zs = new QList<QString>(); zs->append(ZS);
+            w->getRPC()->testSetZAddresses(zs);
+            ui->inputsCombo->clear(); ui->inputsCombo->addItem(T, 3.00010001); ui->inputsCombo->setCurrentIndex(0);
+            ui->Address1->setText(R); ui->Amount1->setText("3");
+
+            Tx tx = w->testCreateTxFromSendPage();
+            QVERIFY2(tx.autoShieldGuardActive, "a 1-zat change must arm the snapshot guard");
+            bool changeToZS = false;
+            for (const auto& to : tx.toAddrs)
+                if (to.addr == ZS) { changeToZS = true; QCOMPARE((qint64)llround(to.amount * 1e8), (qint64)1); }
+            QVERIFY2(changeToZS, "the 1-zat change must route to Sapling");
+            settleAndDelete(w);
+        }
+
+        QSettings().remove("options/autoshield");
+        QSettings().sync();
+    }
+
+    // ---- P14: custom-fee change sizing. The change and the stamped target must reflect a
+    // non-default fee, in exact zatoshis (5 - 3 - 0.001 = 1.999).
+    void p14_customFeeChangeSizing() {
+        MainWindow* w = makeWindow(); auto* ui = w->ui;
+        const QString T  = "t1HsdDMzmJfq4vc7T17XYjEkLMLvbgM1fCi";
+        const QString ZS = "zs1gv64eu0v2wx7raxqxlmj354y9ycznwaau9kduljzczxztvs4qcl00kn2sjxtejvrxnkucw5xx9u";
+        const QString R  = "zs10m00rvkhfm4f7n23e4sxsx275r7ptnggx39ygl0vy46j9mdll5c97gl6dxgpk0njuptg2mn9w5s";
+
+        QSettings().setValue("options/autoshield", true); QSettings().sync();
+        Settings::getInstance()->setAllowCustomFees(true);
+
+        auto* bals = new QMap<QString, double>(); (*bals)[T] = 5.0;
+        w->getRPC()->testSetBalances(bals);
+        auto* utxos = new QList<UnspentOutput>();
+        utxos->append(UnspentOutput{ T, "txid0", "5.0", 10, true, false });
+        w->getRPC()->testSetUTXOs(utxos);
+        auto* zs = new QList<QString>(); zs->append(ZS);
+        w->getRPC()->testSetZAddresses(zs);
+        ui->inputsCombo->clear(); ui->inputsCombo->addItem(T, 5.0); ui->inputsCombo->setCurrentIndex(0);
+        ui->Address1->setText(R); ui->Amount1->setText("3");
+        ui->minerFeeAmt->setText("0.001");              // non-default custom fee
+
+        Tx tx = w->testCreateTxFromSendPage();
+        bool ok = false;
+        for (const auto& to : tx.toAddrs)
+            if (to.addr == ZS) { ok = true; QCOMPARE((qint64)llround(to.amount * 1e8), (qint64)199900000); }
+        QVERIFY2(ok, "change must route to Sapling and reflect the custom fee (1.999)");
+        QCOMPARE(tx.builtTargetZat, (qint64)300100000);  // 3.0 + 0.001
+
+        Settings::getInstance()->setAllowCustomFees(false);
+        QSettings().remove("options/autoshield"); QSettings().sync();
+        settleAndDelete(w);
+    }
+
+    // ---- P15: coinbase-aware band message. A single-recipient PARTIAL coinbase spend
+    // (target fits the confirmed total but exceeds the non-coinbase eligible, and is not a
+    // full-consume shield) must abort up front with the shield-mined-funds guidance.
+    void p15_coinbaseBandMessageAborts() {
+        MainWindow* w = makeWindow(); auto* ui = w->ui;
+        const QString T  = "t1HsdDMzmJfq4vc7T17XYjEkLMLvbgM1fCi";
+        const QString ZS = "zs1gv64eu0v2wx7raxqxlmj354y9ycznwaau9kduljzczxztvs4qcl00kn2sjxtejvrxnkucw5xx9u";
+        const QString R  = "zs10m00rvkhfm4f7n23e4sxsx275r7ptnggx39ygl0vy46j9mdll5c97gl6dxgpk0njuptg2mn9w5s";
+
+        QSettings().setValue("options/autoshield", true); QSettings().sync();
+
+        // 2 non-coinbase + 5 coinbase. Send 3: fits the 7 total, exceeds the 2 non-coinbase
+        // eligible, and is NOT a full-consume single-recipient shield -> band abort.
+        auto* bals = new QMap<QString, double>(); (*bals)[T] = 7.0;
+        w->getRPC()->testSetBalances(bals);
+        auto* utxos = new QList<UnspentOutput>();
+        utxos->append(UnspentOutput{ T, "txid0", "2.0", 10,  true, /*coinbase=*/false });
+        utxos->append(UnspentOutput{ T, "cb0",   "5.0", 100, true, /*coinbase=*/true  });
+        w->getRPC()->testSetUTXOs(utxos);
+        auto* zs = new QList<QString>(); zs->append(ZS);
+        w->getRPC()->testSetZAddresses(zs);
+        ui->inputsCombo->clear(); ui->inputsCombo->addItem(T, 7.0); ui->inputsCombo->setCurrentIndex(0);
+        ui->Address1->setText(R); ui->Amount1->setText("3");
+
+        armModalDismisser();
+        Tx tx = w->testCreateTxFromSendPage();
+        QVERIFY2(tx.fromAddr.isEmpty(),
+                 "partial coinbase spend (target in (eligible, total]) must abort with the "
+                 "shield-mined-funds message, not silently build a doomed tx");
+
+        QSettings().remove("options/autoshield"); QSettings().sync();
+        settleAndDelete(w);
+    }
+
     // ---- P8: P0-2 — the at-rest "● Synced" pill ↔ loud banner swap ---------------
     // The headline visual-polish change: when fully caught up, the full-width
     // colored "Synced" bar is DEMOTED to a quiet inline pill (green lives on the

--- a/tests/widget/tst_widget.cpp
+++ b/tests/widget/tst_widget.cpp
@@ -765,6 +765,119 @@ private slots:
         settleAndDelete(w);
     }
 
+    // ---- P9: auto-shield change EXCLUDES coinbase UTXOs + integer-zatoshi exactness ---
+    // z_sendmany will not spend coinbase UTXOs in a has-change (multi-output) send
+    // (consensus: bad-txns-coinbase-spend-has-transparent-outputs; coinbase goes only to a
+    // single zaddr, whole value consumed). So the auto-shield change MUST be based on the
+    // CONFIRMED, spendable, NON-COINBASE total only -- otherwise the change overshoots the
+    // funds the daemon can actually spend and the send fails "insufficient funds". This
+    // also pins the integer-zatoshi math: the change is EXACTLY 5 - 3 - 0.0001 = 1.9999
+    // (199990000 zat), not a float-drifted value. FAILS if coinbase leaks into the basis
+    // or the math regresses to double arithmetic.
+    void p9_autoShieldExcludesCoinbase() {
+        MainWindow* w = makeWindow();
+        auto* ui = w->ui;
+
+        const QString T  = "t1HsdDMzmJfq4vc7T17XYjEkLMLvbgM1fCi";
+        const QString ZS = "zs1gv64eu0v2wx7raxqxlmj354y9ycznwaau9kduljzczxztvs4qcl00kn2sjxtejvrxnkucw5xx9u";
+
+        QSettings().setValue("options/autoshield", true);
+        QSettings().sync();
+
+        // T holds 9 ZCL: 5 non-coinbase + 4 mined (coinbase). Only the 5 non-coinbase is
+        // eligible to back a shielded change output.
+        auto* bals = new QMap<QString, double>(); (*bals)[T] = 9.0;
+        w->getRPC()->testSetBalances(bals);
+        auto* utxos = new QList<UnspentOutput>();
+        utxos->append(UnspentOutput{ T, "txid0", "5.0", 10,  true, /*coinbase=*/false });
+        utxos->append(UnspentOutput{ T, "txid1", "4.0", 100, true, /*coinbase=*/true  });
+        w->getRPC()->testSetUTXOs(utxos);
+        auto* zs = new QList<QString>(); zs->append(ZS);
+        w->getRPC()->testSetZAddresses(zs);
+
+        ui->inputsCombo->clear();
+        ui->inputsCombo->addItem(T, 9.0);
+        ui->inputsCombo->setCurrentIndex(0);
+        // Recipient is a DIFFERENT Sapling addr so ZS stays free as the change sink.
+        ui->Address1->setText("zs10m00rvkhfm4f7n23e4sxsx275r7ptnggx39ygl0vy46j9mdll5c97gl6dxgpk0njuptg2mn9w5s");
+        ui->Amount1->setText("3");
+
+        Tx tx = w->testCreateTxFromSendPage();
+
+        QVERIFY2(!tx.fromAddr.isEmpty(),
+                 "coinbase-excluded change must NOT abort: 5 non-coinbase ZCL covers 3 + fee");
+        bool changeToSapling = false;
+        for (const auto& to : tx.toAddrs) {
+            if (to.addr == ZS) {
+                changeToSapling = true;
+                // Based on the 5 NON-coinbase ZCL only: 5 - 3 - 0.0001 = 1.9999.
+                QVERIFY2(to.amount > 1.9 && to.amount < 2.0,
+                         qPrintable(QString("change must exclude coinbase (~1.9999), got: %1")
+                                    .arg(to.amount)));
+                // Integer-zatoshi EXACTNESS: exactly 199990000 zat, no float drift.
+                QCOMPARE((qint64)llround(to.amount * 1e8), (qint64)199990000);
+            }
+            QVERIFY2(to.addr != T,
+                     "PRIV-10: change must NEVER be routed back to a transparent address");
+        }
+        QVERIFY2(changeToSapling,
+                 "auto-shield change (from the non-coinbase balance) must route to Sapling");
+
+        QSettings().remove("options/autoshield");
+        QSettings().sync();
+        settleAndDelete(w);
+    }
+
+    // ---- P10: coinbase-only "shield everything" is NOT blocked (no change output) ------
+    // A miner shielding a coinbase-only t-address via "Send max" sends the whole balance
+    // to a single Sapling z-address with NO change -- the daemon legitimately consumes the
+    // coinbase UTXOs in full to that lone zaddr. The auto-shield path must NOT abort this
+    // (it has no non-coinbase change to shield) and must NOT fabricate a change output
+    // (which would make the tx multi-output and the coinbase unspendable). FAILS if the
+    // coinbase exclusion regresses this into a fail-closed abort or adds a stray output.
+    void p10_autoShieldCoinbaseOnlyShieldEverything() {
+        MainWindow* w = makeWindow();
+        auto* ui = w->ui;
+
+        const QString T  = "t1HsdDMzmJfq4vc7T17XYjEkLMLvbgM1fCi";
+        const QString ZS = "zs1gv64eu0v2wx7raxqxlmj354y9ycznwaau9kduljzczxztvs4qcl00kn2sjxtejvrxnkucw5xx9u";
+
+        QSettings().setValue("options/autoshield", true);
+        QSettings().sync();
+
+        // T holds 4 ZCL, ALL of it mined (coinbase). No non-coinbase funds exist.
+        auto* bals = new QMap<QString, double>(); (*bals)[T] = 4.0;
+        w->getRPC()->testSetBalances(bals);
+        auto* utxos = new QList<UnspentOutput>();
+        utxos->append(UnspentOutput{ T, "txidcb", "4.0", 100, true, /*coinbase=*/true });
+        w->getRPC()->testSetUTXOs(utxos);
+        // Deliberately seed NO Sapling z-address: the no-change path must not need (nor
+        // try to create) a change sink. If the logic wrongly treated this as change>0 it
+        // would hit the fail-closed create and return an INVALID Tx -- caught below.
+        w->getRPC()->testSetZAddresses(new QList<QString>());
+
+        ui->inputsCombo->clear();
+        ui->inputsCombo->addItem(T, 4.0);
+        ui->inputsCombo->setCurrentIndex(0);
+        ui->Address1->setText(ZS);     // single Sapling recipient
+        ui->Amount1->setText("3.9999"); // send everything: 4.0 - 0.0001 fee
+
+        Tx tx = w->testCreateTxFromSendPage();
+
+        QVERIFY2(!tx.fromAddr.isEmpty(),
+                 "coinbase-only 'shield everything' must NOT abort (no non-coinbase change "
+                 "to shield; the daemon consumes the coinbase fully to the lone z-recipient)");
+        QCOMPARE(tx.toAddrs.size(), 1);                // recipient only, NO change output
+        QCOMPARE(tx.toAddrs[0].addr, ZS);
+        for (const auto& to : tx.toAddrs)
+            QVERIFY2(to.addr != T,
+                     "no transparent output may be built for a coinbase shield");
+
+        QSettings().remove("options/autoshield");
+        QSettings().sync();
+        settleAndDelete(w);
+    }
+
     // ---- P8: P0-2 — the at-rest "● Synced" pill ↔ loud banner swap ---------------
     // The headline visual-polish change: when fully caught up, the full-width
     // colored "Synced" bar is DEMOTED to a quiet inline pill (green lives on the


### PR DESCRIPTION
## What this fixes

Sending from a **t-address with auto-shield ON** could fail with "insufficient funds" or leave a stray **public transparent-change** output. GUI-only — the daemon does not need rebuilding.

Two root causes, both verified against the daemon source (not assumed):

1. **Float drift.** `z_sendmany` has no change-address parameter — taddr change always goes to a fresh *public* keypool t-addr, so the only way to keep change private is an explicit Sapling output that consumes the spendable inputs *exactly*. The old `change = confirmed − amount − fee` in `double` left a few stray zatoshis → the daemon either rejected the tx or emitted public transparent change. Now computed in **integer zatoshis** (`toZat`/`llround`).
2. **Coinbase blind spot.** The old basis counted coinbase UTXOs, which the daemon won't spend in a has-change (multi-output) send (consensus `bad-txns-coinbase-spend-has-transparent-outputs`). For mined funds this overshot the daemon's real input set → "insufficient funds." The basis is now **confirmed, spendable, non-coinbase** (a `generated` flag is tracked from `listunspent` onto `UnspentOutput`), matching the daemon's `find_utxos(false)` selection. A coinbase-only "shield everything" (single zaddr, no change) still works because affordability is checked against the coinbase-*inclusive* total and no change output is added when there's no non-coinbase change.

Files: `src/sendtab.cpp`, `src/rpc.cpp`, `src/rpc.h`, `src/mainwindow.h`, `src/balancestablemodel.h`, `tests/widget/tst_widget.cpp`.

## Verification (independent)

Built + tested in the proot / static-Qt (glibc 2.31) chroot — including the **L0 run the author couldn't do** in their env:

- **L0 `tst_logic`: 103 passed / 0 failed**
- **L1 `tst_widget`: 34 passed / 0 failed** — `p9_autoShieldExcludesCoinbase` ✅, `p10_autoShieldCoinbaseOnlyShieldEverything` ✅

## Review verdict: **LAND** (land-with-nits) — no blockers

Adversarial money-safety review (5 lenses: leak / coinbase-consensus / integer-math / affordability / test-quality) against the daemon source.

**Confirmed sound:**
- Integer-zatoshi round-trip (`changeZat → (double)/1e8 → getDecimalString → daemon ParseFixedPoint`) is **exact across the entire reachable money range** (verified exhaustively; max drift 0.25 zat < 0.5, MAX_MONEY 2.1e15 < 2⁵³). Closes the float-residual public-change leak vector.
- The non-coinbase vs coinbase-inclusive split **exactly matches** the daemon's two `find_utxos()` modes (incl. immature-coinbase handling via `AvailableCoins`).
- In the no-race steady state the `changeZat>0` path is **provably leak-free** (daemon residual is forced to exactly 0, so its transparent-change path is never reached).
- No path loses funds, overspends, or falsely blocks a valid send.

**Two things worth addressing (non-blocking):**
1. **Comment overclaim** — the `changeZat<=0` branch comment says it "can never silently leak." True for the steady state but not in the snapshot-race window below; please scope the comment + add the caveat.
2. **Pre-existing snapshot-race privacy leak (not introduced here):** the GUI sizes change against a poll-snapshot eligible set, but `z_sendmany` carries no input-pinning list, so the daemon re-selects live. If a transparent UTXO **confirms to the from-addr between the GUI's poll and the deferred `z_sendmany` execution**, the daemon can ascending-select past the target and emit public transparent change of the surplus. Narrow (only an actively-receiving t-addr during the proof window), can't lose funds, and **this PR makes the common case strictly better**. Mitigation (re-poll before send, or daemon-side input pinning) is a follow-up.

## Follow-ups (file as issues, not blocking this PR)
- Coinbase-aware **friendly message** for the `(eligible, total]` band: validate multi-output / has-change sends against the *non-coinbase* eligible total so the user gets the up-front message instead of a raw daemon rejection (daemon already backstops; pure UX).
- **Snapshot-race** mitigation (re-poll-before-send or input pinning).
- **Tests:** (a) multi-recipient coinbase-only send (GUI green-lights a tx the daemon rejects — highest value); (b) non-coinbase exact send-max `changeZat==0` boundary asserts `toAddrs.size()==1`; (c) custom-fee (8-dp) change sizing. Re-title `p10` (it pins "no fabricated change / no abort", not coinbase-exclusion discrimination).

## Not yet done
Not broadcast on mainnet — verification is daemon-source + L0/L1 + review. A real small `t→z` send-with-change against a funded node is the recommended final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
