### PR TITLE
wallet(send): integer-zatoshi funds guard + close changeZat==0 auto-shield leak leg

### DIFF
--- a/src/sendtab.cpp
+++ b/src/sendtab.cpp
@@ -734,11 +734,21 @@ Tx MainWindow::createTxFromSendPage() {
             tx.autoShieldGuardActive = true;
             tx.autoShieldFullConsume = true;
             tx.builtTargetZat        = targetZat;
+        } else {
+            // changeZat == 0 with coinbase left idle (targetZat == eligibleZat <
+            // confirmedTotalZat). This leg is ONLY ever the exact non-coinbase consume: a
+            // changeZat < 0 (targetZat > eligibleZat) that is not the targetZat==confirmedTotal
+            // shield was already band-aborted above. The daemon funds the non-coinbase eligible
+            // set EXACTLY with ZERO change -- a clean, fundable shielding tx (NOT a reject) --
+            // so it is race-prone exactly like the changeZat>0 path: if a non-coinbase t-UTXO
+            // confirms at the from-addr during the confirm dwell, the live eligible set grows
+            // and the daemon emits the surplus as PUBLIC transparent change. Arm the
+            // eligible-set guard so verifyAutoShieldUnchanged() re-polls and aborts fail-closed
+            // if the live non-coinbase eligible total moved.
+            tx.autoShieldGuardActive = true;
+            tx.builtEligibleZat      = eligibleZat;
+            tx.builtTargetZat        = targetZat;
         }
-        // Remaining changeZat <= 0 (targetZat < confirmedTotalZat): coinbase is present and
-        // the spend consumes exactly the non-coinbase eligible set, leaving coinbase behind.
-        // The daemon cannot fund a clean transparent-free spend in this shape (it rejects),
-        // so there is no surplus that could leak -- nothing to guard.
     }
 
     return tx;
@@ -1345,11 +1355,18 @@ QString MainWindow::doSendTxValidations(Tx tx) {
     if (!Settings::getInstance()->isSyncing()) {
         auto bals = rpc ? rpc->getAllBalances() : nullptr;
         if (bals && bals->contains(tx.fromAddr)) {
-            double displayed = bals->value(tx.fromAddr);          // minconf=0 total (incl. 0-conf)
-            double confirmed = spendableOrFallback(tx.fromAddr);  // confirmed-spendable, fails open
-            double total     = tx.fee;
+            // Compare in INTEGER ZATOSHIS, never double. A "send max" / shield makes
+            // total == amount+fee land a fraction-of-a-zatoshi ABOVE the balance in IEEE-754
+            // (e.g. 0.1199 + 0.0001 -> 0.120000000002 vs a 0.12 balance -> 0.119999999996),
+            // which false-aborts "Not enough funds" with BOTH sides displaying "0.12" -- the
+            // exact dead-end the user hit. Rounding each value to the nearest zatoshi removes
+            // the drift (the spendableOrFallback -> confirmedSpendableZat rewire fixed the
+            // auto-shield block but NOT this generic guard).
+            const qint64 displayedZat = toZat(bals->value(tx.fromAddr));    // minconf=0 total
+            const qint64 confirmedZat = toZat(spendableOrFallback(tx.fromAddr));
+            qint64 totalZat = toZat(tx.fee);
             for (auto toAddr : tx.toAddrs)
-                total += toAddr.amount;
+                totalZat += toZat(toAddr.amount);
 
             // Three-way guard so the user is never dead-ended:
             //  1) confirmed >= total            -> PASS (proceed exactly as today). NEVER
@@ -1361,21 +1378,20 @@ QString MainWindow::doSendTxValidations(Tx tx) {
             //                                       today's "only holds %2" message.
             // The daemon's own insufficient-funds rejection (mapped by humaneSendError)
             // remains the final backstop; this is just an EARLIER, friendlier check.
-            if (confirmed >= total) {
+            if (confirmedZat >= totalZat) {
                 // ok -- fall through, do not block
             }
-            else if (displayed >= total) {
-                double stillConfirming = total - confirmed;
-                if (stillConfirming < 0) stillConfirming = 0;
+            else if (displayedZat >= totalZat) {
+                const qint64 stillZat = (totalZat > confirmedZat) ? (totalZat - confirmedZat) : 0;
                 return tr("%1 of these funds is still confirming (about a few minutes). "
                           "You can shield or send it as soon as it confirms.")
-                       .arg(Settings::getZCLDisplayFormat(stillConfirming));
+                       .arg(Settings::getZCLDisplayFormat((double)stillZat / 1e8));
             }
             else {
                 return tr("Not enough funds. You're trying to send %1 (including the fee), "
                           "but this address only holds %2.")
-                       .arg(Settings::getZCLDisplayFormat(total))
-                       .arg(Settings::getZCLDisplayFormat(displayed));
+                       .arg(Settings::getZCLDisplayFormat((double)totalZat / 1e8))
+                       .arg(Settings::getZCLDisplayFormat((double)displayedZat / 1e8));
             }
         }
     }

--- a/tests/widget/tst_widget.cpp
+++ b/tests/widget/tst_widget.cpp
@@ -1282,6 +1282,97 @@ private slots:
         settleAndDelete(w);
     }
 
+    // ---- P17: exact non-coinbase consume with IDLE COINBASE is race-guarded --------------
+    // changeZat==0 leg: target == the non-coinbase eligible set while coinbase sits idle
+    // (target < confirmedTotal). No change row is built, but the daemon funds the non-coinbase
+    // set EXACTLY (zero change) -- a clean, fundable shield, race-prone like changeZat>0: if a
+    // non-coinbase UTXO confirms during the dwell, the surplus leaks as PUBLIC change. The
+    // ELIGIBLE guard must arm and the gate must abort on a grown eligible set. (Regression for
+    // the review-found unguarded leak leg; the prior comment wrongly claimed "nothing to guard".)
+    void p17_autoShieldExactNonCoinbaseConsumeRaceGuard() {
+        MainWindow* w = makeWindow(); auto* ui = w->ui;
+        const QString T = "t1HsdDMzmJfq4vc7T17XYjEkLMLvbgM1fCi";
+        const QString R = "zs1gv64eu0v2wx7raxqxlmj354y9ycznwaau9kduljzczxztvs4qcl00kn2sjxtejvrxnkucw5xx9u";
+
+        QSettings().setValue("options/autoshield", true); QSettings().sync();
+
+        // 5 non-coinbase + 4 coinbase. Send EXACTLY the non-coinbase 5 (4.9999 + 0.0001 fee).
+        auto* bals = new QMap<QString, double>(); (*bals)[T] = 9.0;
+        w->getRPC()->testSetBalances(bals);
+        auto* utxos = new QList<UnspentOutput>();
+        utxos->append(UnspentOutput{ T, "nc0", "5.0", 10,  true, /*coinbase=*/false });
+        utxos->append(UnspentOutput{ T, "cb0", "4.0", 100, true, /*coinbase=*/true  });
+        w->getRPC()->testSetUTXOs(utxos);
+        auto* zs = new QList<QString>(); zs->append(R);
+        w->getRPC()->testSetZAddresses(zs);
+        ui->inputsCombo->clear(); ui->inputsCombo->addItem(T, 9.0); ui->inputsCombo->setCurrentIndex(0);
+        ui->Address1->setText(R); ui->Amount1->setText("4.9999");
+
+        Tx tx = w->testCreateTxFromSendPage();
+        QVERIFY2(!tx.fromAddr.isEmpty(), "exact non-coinbase consume must not abort");
+        QCOMPARE(tx.toAddrs.size(), 1);                       // recipient only, NO change row
+        QVERIFY2(tx.autoShieldGuardActive && !tx.autoShieldFullConsume,
+                 "changeZat==0 with idle coinbase must arm the ELIGIBLE guard (not full-consume)");
+        QCOMPARE(tx.builtEligibleZat, (qint64)500000000);     // sized against the 5.0 non-coinbase
+        for (const auto& to : tx.toAddrs)
+            QVERIFY2(to.addr != T, "no transparent output for the exact-consume shield");
+
+        // (a) eligible GREW (a 2.0 non-coinbase confirmed during the dwell) -> MUST abort.
+        {
+            auto* grown = new QList<UnspentOutput>();
+            grown->append(UnspentOutput{ T, "nc0", "5.0", 10,  true, false });
+            grown->append(UnspentOutput{ T, "cb0", "4.0", 100, true, true  });
+            grown->append(UnspentOutput{ T, "nc1", "2.0", 10,  true, false });
+            w->getRPC()->testSetRepollUTXOs(grown);
+            armModalDismisser();
+            QVERIFY2(!w->testVerifyAutoShield(tx),
+                     "a grown non-coinbase eligible set MUST abort (surplus would leak public change)");
+        }
+        // (b) UNCHANGED -> the send proceeds.
+        {
+            auto* same = new QList<UnspentOutput>();
+            same->append(UnspentOutput{ T, "nc0", "5.0", 10,  true, false });
+            same->append(UnspentOutput{ T, "cb0", "4.0", 100, true, true  });
+            w->getRPC()->testSetRepollUTXOs(same);
+            QVERIFY2(w->testVerifyAutoShield(tx), "an unchanged eligible set => gate passes");
+        }
+
+        QSettings().remove("options/autoshield"); QSettings().sync();
+        settleAndDelete(w);
+    }
+
+    // ---- P18: doSendTxValidations must use INTEGER zatoshis (no float false-abort) --------
+    // A "send max" / shield of the whole balance makes amount+fee == balance, which floats a
+    // fraction-of-a-zatoshi ABOVE the balance (0.1199 + 0.0001 -> 0.120000000002 vs a 0.12
+    // balance -> 0.119999999996). The generic insufficient-funds guard must NOT false-abort
+    // "Not enough funds" — the exact dead-end the user hit on the combined bundle.
+    void p18_doSendTxValidationsNoFloatFalseAbort() {
+        MainWindow* w = makeWindow();
+        const QString T = "t1HsdDMzmJfq4vc7T17XYjEkLMLvbgM1fCi";
+        const QString R = "zs1gv64eu0v2wx7raxqxlmj354y9ycznwaau9kduljzczxztvs4qcl00kn2sjxtejvrxnkucw5xx9u";
+
+        auto* bals = new QMap<QString, double>(); (*bals)[T] = 0.12;
+        w->getRPC()->testSetBalances(bals);
+        auto* utxos = new QList<UnspentOutput>();
+        utxos->append(UnspentOutput{ T, "txid0", "0.12", 56, true, /*coinbase=*/false });
+        w->getRPC()->testSetUTXOs(utxos);
+
+        Tx tx; tx.fromAddr = T; tx.fee = 0.0001;
+        ToFields f; f.addr = R; f.amount = 0.1199;            // Max shield: 0.1199 + 0.0001 == 0.12
+        tx.toAddrs.append(f);
+
+        const QString err = w->doSendTxValidations(tx);
+        QVERIFY2(err.isEmpty(),
+                 qPrintable("shielding the whole balance (amount+fee==balance) must NOT false-abort: " + err));
+
+        // And a genuine overspend STILL aborts (don't over-correct): send 0.13 of a 0.12 balance.
+        Tx over; over.fromAddr = T; over.fee = 0.0001;
+        ToFields g; g.addr = R; g.amount = 0.13; over.toAddrs.append(g);
+        QVERIFY2(!w->doSendTxValidations(over).isEmpty(), "a real overspend must still be blocked");
+
+        settleAndDelete(w);
+    }
+
     // ---- P8: P0-2 — the at-rest "● Synced" pill ↔ loud banner swap ---------------
     // The headline visual-polish change: when fully caught up, the full-width
     // colored "Synced" bar is DEMOTED to a quiet inline pill (green lives on the


### PR DESCRIPTION
Two fixes on the canonical send path (found after PR #18 merged):

**1. The Max-shield 'Not enough funds' is NOT actually cured.** `doSendTxValidations` still compares in `double`. A shield of the whole balance makes amount+fee == balance, which floats just above it (0.1199 + 0.0001 -> 0.120000000002 vs 0.12 -> 0.119999999996), false-aborting with both sides showing 0.12 — bob hit this on the combined bundle. The spendableOrFallback->confirmedSpendableZat rewire fixed the auto-shield block but not this generic guard. Now compared in integer zatoshis.

**2. Privacy-leak race (my adversarial review of PR #18, verified).** The auto-shield `changeZat==0` leg (target == non-coinbase eligible, coinbase idle) armed no race guard, and the comment wrongly claimed the daemon rejects it. It funds the non-coinbase set exactly with zero change, so a UTXO confirming during the confirm dwell leaks the surplus as PUBLIC change. Now arms the eligible-set guard.

Tests: p18 (full-balance shield does not false-abort, real overspend still blocks) + p17 (changeZat==0 idle-coinbase arms the guard + aborts on a grown set). **L1: 44 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)