### PR TITLE
Send form: don't-make-me-think UX redesign (presentation-only)

### DIFF
--- a/docs/SEND_UX.md
+++ b/docs/SEND_UX.md
@@ -1,0 +1,40 @@
+# Send form — UX redesign ("don't make me think")
+
+Goal: a non-expert should be able to answer the three questions that actually matter —
+**who am I paying, exactly how much will it cost, and will the world see this** — *before*
+they ever reach the confirm dialog. Every change here is presentation-only; none touch the
+stabilized money/validation logic (`createTxFromSendPage`, `doSendTxValidations`,
+`confirmedSpendableZat`, `spendableOrFallback`, `verifyAutoShieldUnchanged`).
+
+## What changed, and why
+
+| # | Change | Why (crypto-UX / Krug principle) |
+|---|--------|----------------------------------|
+| 1 | **Live privacy badge** above the form (`sendPrivacyBadge`) — green *Private*, *Shielding*, amber *Public*, red *De-shield* | The single most important fact for a shielded wallet was invisible until the confirm modal. Now the page itself tells one consistent privacy story, in plain words, as you type. Driven by the wallet's own `sendCategoryOf()` classifier — a pure display echo that errs toward the *stronger* warning. |
+| 2 | Plain-language labels: **Pay from / Available to send / Pay to / Network fee / Review & send** | "From", "Address Balance", "Miner Fee" are jargon. Self-evident words remove the need to interpret. |
+| 3 | **Teaching placeholders** — address: *"Paste a z-address (private) or t-address (public)"*; amount: *"0.00"* | Placeholder-as-label-word taught nothing. Now the field shows what a valid input looks like. |
+| 4 | Always-on **`ZCL` unit** next to amount and fee | A money field with no unit is a classic make-me-think; the unit is visible before you type. |
+| 5 | **Live amount border** (green when > 0, red when not), mirroring the existing live address border | Catches mistakes as you type, not as a surprise failure at Send. Local format check only — never compares to balance. |
+| 6 | **`Review & send`** is the green primary/default button; **`Cancel` is forgiving** (confirms before discarding typed work) | The irreversible action is the visual anchor and maps to Enter; Cancel no longer silently destroys a half-typed payment. |
+| 7 | **`Send all`** replaces the bare "Max Available" checkbox (checkable button) | A checkbox in the middle of the amount row was ambiguous ("max of what? did it break the field?"). An honest button reads as an action. Routes through the unchanged max math. |
+| 8 | **Memos discoverable**: button reads *"Add private note"*, tooltips explain encryption, the note renders at base font prefixed *"Private note:"* | The big privacy feature (encrypted notes) was a greyed button with a hover-only tooltip. |
+| 9 | **Running total** line: *"You'll send 1.50 + 0.0001 fee = 1.5001 ZCL (~$X)"* | No more mental math; the total is shown live. Aggregates on-screen amounts only — no new money math. |
+| 10 | **De-nested** the single-recipient box-in-a-box; fee field no longer flashes a literal `0` | Less visual noise; calmer default. |
+
+## Money-safety
+
+All twelve changes are in safe seams (`mainwindow.ui`, `setupSendTab`/`addAddressSection`,
+copy/label/qss, the presentation-only `updateSendPrivacyBadge`/`updateSendTotals`). The
+privacy badge and confirm badge are **pure display echoes** of `sendCategoryOf()` (fail-safe:
+an unparseable recipient is treated as transparent → stronger public/de-shield verdict). The
+amount border is a local `> 0` check that never calls `doSendTxValidations`. The running total
+only sums values already on screen; the authoritative amount still comes solely from
+`createTxFromSendPage`. `Send all` keeps `Max1` checkable and routes through the unchanged
+`maxAmountChecked`/`recomputeMaxIfChecked` path (only the widget class + a `toggled(bool)`
+signal adapter changed).
+
+## Deferred (next pass)
+- Human-readable From-combo items (label + type word + spaced balance) — touches the `(`-split
+  contract that recovers `tx.fromAddr`; land alone with a byte-identical round-trip assertion.
+- Per-recipient remove control; per-row privacy badges; QR-scan / paste-and-fill on the address.
+- Confirm-dialog: reuse the page badge component + "Total leaving / Left after" rows.

--- a/docs/SEND_UX.md
+++ b/docs/SEND_UX.md
@@ -33,6 +33,11 @@ only sums values already on screen; the authoritative amount still comes solely 
 `maxAmountChecked`/`recomputeMaxIfChecked` path (only the widget class + a `toggled(bool)`
 signal adapter changed).
 
+**Memo note:** the "private note" framing lives only in the button label + tooltips. The memo
+text label (`MemoTxt%N`) is stored **raw** and is byte-identical to canonical, because
+`createTxFromSendPage` reads it verbatim as the on-chain memo — so no decoration is ever added
+to the payload. (An earlier draft prefixed the label and was caught + reverted in review.)
+
 ## Deferred (next pass)
 - Human-readable From-combo items (label + type word + spaced balance) — touches the `(`-split
   contract that recovers `tx.fromAddr`; land alone with a byte-identical round-trip assertion.

--- a/res/styles/dark.qss
+++ b/res/styles/dark.qss
@@ -468,6 +468,31 @@ QLabel[badge="true"][tone="deshield"] {
 }
 
 /* ============================================================================
+ * SEND FORM "don't make me think" affordances.
+ *  - sendPrivacyBadge: live private/public verdict above the form. When a verdict
+ *    is set it carries badge/tone (styled above); at rest (no tone) it is a quiet
+ *    neutral hint, not an alarm.
+ *  - sendAddressBalance: a read-only QLineEdit that should read as a STATUS value,
+ *    not a clickable input (no border / focus ring, bold).
+ *  - sendTotalsLine: the running "You'll send X + fee = Z" summary, quiet + secondary.
+ * ============================================================================ */
+QLabel#sendPrivacyBadge {
+    padding: 6px 10px;
+    color: #9aa0a6;                  /* neutral resting hint */
+    font-style: italic;
+}
+QLineEdit#sendAddressBalance {
+    border: none;
+    background: transparent;
+    font-weight: 700;
+    color: #e6e6e6;
+}
+QLabel#sendTotalsLine {
+    color: #c7ccd1;
+    font-weight: 600;
+}
+
+/* ============================================================================
  * SOFTENED PUBLIC WARNING CALLOUT (Polish P1). The Receive transparent (t-Addr)
  * warning reuses lblSproutWarning. Instead of a full-bold red crash-message, it
  * is an AMBER callout card (amber = PUBLIC/transparent everywhere): tinted bg +

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -466,6 +466,11 @@ private:
 
     void addressChanged(int number, const QString& text);
     void amountChanged (int number, const QString& text);
+    // PRESENTATION-ONLY helpers (no money/zatoshi math): the live private/public verdict
+    // badge above the Send form (echoes sendCategoryOf), and the running "You'll send X +
+    // fee = Z" totals line (aggregates on-screen amounts only).
+    void updateSendPrivacyBadge();
+    void updateSendTotals();
 
     void addNewZaddr(bool sapling);
     std::function<void(bool)> addZAddrsToComboList(bool sapling);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -244,12 +244,22 @@
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_4">
         <item>
+         <widget class="QLabel" name="sendPrivacyBadge">
+          <property name="text">
+           <string>Set who you are paying to see if this send is private</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QGroupBox" name="groupBox_4">
           <property name="autoFillBackground">
            <bool>false</bool>
           </property>
           <property name="title">
-           <string>From</string>
+           <string>Pay from</string>
           </property>
           <property name="flat">
            <bool>false</bool>
@@ -267,7 +277,7 @@
              <item>
               <widget class="QLabel" name="label_5">
                <property name="text">
-                <string>Address Balance</string>
+                <string>Available to send</string>
                </property>
               </widget>
              </item>
@@ -354,7 +364,10 @@
                <item>
                 <widget class="QGroupBox" name="verticalGroupBox">
                  <property name="title">
-                  <string>Recipient</string>
+                  <string/>
+                 </property>
+                 <property name="flat">
+                  <bool>true</bool>
                  </property>
                  <layout class="QVBoxLayout" name="sendAddressLayout">
                   <item>
@@ -362,14 +375,14 @@
                     <item>
                      <widget class="QLabel" name="label_4">
                       <property name="text">
-                       <string>Address</string>
+                       <string>Pay to</string>
                       </property>
                      </widget>
                     </item>
                     <item>
                      <widget class="QLineEdit" name="Address1">
                       <property name="placeholderText">
-                       <string>Address</string>
+                       <string>Paste a z-address (private) or t-address (public)</string>
                       </property>
                      </widget>
                     </item>
@@ -403,7 +416,14 @@
                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                       </property>
                       <property name="placeholderText">
-                       <string>Amount</string>
+                       <string>0.00</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="amountUnit1">
+                      <property name="text">
+                       <string>ZCL</string>
                       </property>
                      </widget>
                     </item>
@@ -415,9 +435,12 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QCheckBox" name="Max1">
+                     <widget class="QPushButton" name="Max1">
+                      <property name="checkable">
+                       <bool>true</bool>
+                      </property>
                       <property name="text">
-                       <string>Max Available</string>
+                       <string>Send all</string>
                       </property>
                      </widget>
                     </item>
@@ -443,7 +466,7 @@
                        <string/>
                       </property>
                       <property name="text">
-                       <string>Memo</string>
+                       <string>Add private note</string>
                       </property>
                      </widget>
                     </item>
@@ -579,7 +602,7 @@
           <item>
            <widget class="QLabel" name="minerFeeLabel">
             <property name="text">
-             <string>Miner Fee</string>
+             <string>Network fee</string>
             </property>
            </widget>
           </item>
@@ -592,7 +615,14 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>0</string>
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="feeUnit">
+            <property name="text">
+             <string>ZCL</string>
             </property>
            </widget>
           </item>
@@ -604,9 +634,22 @@
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_17">
+           <spacer name="horizontalSpacer_totals">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="sendTotalsLine">
             <property name="text">
-             <string notr="true"/>
+             <string/>
             </property>
            </widget>
           </item>
@@ -632,7 +675,10 @@
              </size>
             </property>
             <property name="text">
-             <string>Send</string>
+             <string>Review &amp; send</string>
+            </property>
+            <property name="default">
+             <bool>true</bool>
             </property>
             <property name="flat">
              <bool>false</bool>

--- a/src/sendtab.cpp
+++ b/src/sendtab.cpp
@@ -38,8 +38,13 @@ void MainWindow::setupSendTab() {
     // Hook up add address button click
     QObject::connect(ui->addAddressButton, &QPushButton::clicked, this, &MainWindow::addAddressSection);
 
-    // Max available Checkbox
-    QObject::connect(ui->Max1, &QCheckBox::stateChanged, this, &MainWindow::maxAmountChecked);
+    // "Send all" — now a checkable button (was a bare checkbox). It stays checkable so
+    // recomputeMaxIfChecked()/setChecked(false) keep working; toggled(bool) is adapted to
+    // the existing maxAmountChecked(int) slot so the max math (recomputeMaxIfChecked) is
+    // entirely unchanged.
+    QObject::connect(ui->Max1, &QPushButton::toggled, this, [this](bool on) {
+        maxAmountChecked(on ? Qt::Checked : Qt::Unchecked);
+    });
 
     // The first Address button
     QObject::connect(ui->Address1, &QLineEdit::textChanged, [=] (auto text) {
@@ -78,7 +83,16 @@ void MainWindow::setupSendTab() {
         ui->lblMinerFeeUSD->setText(Settings::getUSDFormat(txt.toDouble()));
         recomputeMaxIfChecked();   // fee changed -> the "Send max" amount must follow
     });
-    ui->minerFeeAmt->setText(Settings::getDecimalString(Settings::getMinerFee()));    
+    ui->minerFeeAmt->setText(Settings::getDecimalString(Settings::getMinerFee()));
+    // Network-fee read-only hint (custom fees default OFF): explain the greyed field
+    // instead of leaving a mysterious dead control.
+    if (!Settings::getInstance()->getAllowCustomFees()) {
+        QString feeHint = tr("Default network fee. Turn on “Allow custom fees” in Settings to change it.");
+        ui->minerFeeAmt->setToolTip(feeHint);
+        ui->minerFeeLabel->setToolTip(feeHint);
+    }
+    // Keep the running totals line current when the fee changes.
+    QObject::connect(ui->minerFeeAmt, &QLineEdit::textChanged, [=](auto) { updateSendTotals(); });
 
      // Set up focus enter to set fees
     QObject::connect(ui->tabWidget, &QTabWidget::currentChanged, [=] (int pos) {
@@ -91,10 +105,8 @@ void MainWindow::setupSendTab() {
     auto feesValidator = new QRegExpValidator(QRegExp("[0-9]{0,8}\\.?[0-9]{0,8}")); 
     ui->minerFeeAmt->setValidator(feesValidator);
 
-    // Font for the first Memo label
-    QFont f = ui->Address1->font();
-    f.setPointSize(f.pointSize() - 1);
-    ui->MemoTxt1->setFont(f);
+    // The first Memo label uses the base font (no shrink) so an entered private note
+    // is readable, not a tiny afterthought.
 
     // Recurring button
     QObject::connect(ui->chkRecurring, &QCheckBox::stateChanged, [=] (int checked) {
@@ -219,6 +231,8 @@ void MainWindow::inputComboTextChanged(int index) {
     ui->sendAddressBalance->setText(balFmt);
     ui->sendAddressBalanceUSD->setText(Settings::getUSDFormat(spendable));
     recomputeMaxIfChecked();   // from-address changed -> its balance drives the "Send max" amount
+    updateSendPrivacyBadge();  // from-address private/public-ness feeds the verdict
+    updateSendTotals();
 }
 
     
@@ -235,12 +249,12 @@ void MainWindow::addAddressSection() {
     auto horizontalLayout_12 = new QHBoxLayout();
     horizontalLayout_12->setSpacing(6);
     auto label_4 = new QLabel(verticalGroupBox);
-    label_4->setText(tr("Address"));
+    label_4->setText(tr("Pay to"));
     horizontalLayout_12->addWidget(label_4);
 
     auto Address1 = new QLineEdit(verticalGroupBox);
-    Address1->setObjectName(QString("Address") % QString::number(itemNumber)); 
-    Address1->setPlaceholderText(tr("Address"));
+    Address1->setObjectName(QString("Address") % QString::number(itemNumber));
+    Address1->setPlaceholderText(tr("Paste a z-address (private) or t-address (public)"));
     QObject::connect(Address1, &QLineEdit::textChanged, [=] (auto text) {
         this->addressChanged(itemNumber, text);
     });
@@ -267,18 +281,24 @@ void MainWindow::addAddressSection() {
     horizontalLayout_13->addWidget(label_6);
 
     auto Amount1 = new QLineEdit(verticalGroupBox);
-    Amount1->setPlaceholderText(tr("Amount"));    
-    Amount1->setObjectName(QString("Amount") % QString::number(itemNumber));   
+    Amount1->setPlaceholderText(tr("0.00"));
+    Amount1->setObjectName(QString("Amount") % QString::number(itemNumber));
     Amount1->setBaseSize(QSize(200, 0));
-    Amount1->setAlignment(Qt::AlignRight);    
+    Amount1->setAlignment(Qt::AlignRight);
     // Create the validator for send to/amount fields
-    auto amtValidator = new QRegExpValidator(QRegExp("[0-9]{0,8}\\.?[0-9]{0,8}")); 
+    auto amtValidator = new QRegExpValidator(QRegExp("[0-9]{0,8}\\.?[0-9]{0,8}"));
     Amount1->setValidator(amtValidator);
     QObject::connect(Amount1, &QLineEdit::textChanged, [=] (auto text) {
         this->amountChanged(itemNumber, text);
     });
 
     horizontalLayout_13->addWidget(Amount1);
+
+    // Always-on "ZCL" unit so the amount field's currency is clear before typing.
+    auto amountUnit = new QLabel(verticalGroupBox);
+    amountUnit->setObjectName(QString("amountUnit") % QString::number(itemNumber));
+    amountUnit->setText(tr("ZCL"));
+    horizontalLayout_13->addWidget(amountUnit);
 
     auto AmtUSD1 = new QLabel(verticalGroupBox);
     AmtUSD1->setObjectName(QString("AmtUSD") % QString::number(itemNumber));   
@@ -289,7 +309,7 @@ void MainWindow::addAddressSection() {
 
     auto MemoBtn1 = new QPushButton(verticalGroupBox);
     MemoBtn1->setObjectName(QString("MemoBtn") % QString::number(itemNumber));
-    MemoBtn1->setText(tr("Memo"));    
+    MemoBtn1->setText(tr("Add private note"));
     // Connect Memo Clicked button
     QObject::connect(MemoBtn1, &QPushButton::clicked, [=] () {
         this->memoButtonClicked(itemNumber);
@@ -301,9 +321,7 @@ void MainWindow::addAddressSection() {
 
     auto MemoTxt1 = new QLabel(verticalGroupBox);
     MemoTxt1->setObjectName(QString("MemoTxt") % QString::number(itemNumber));
-    QFont font1 = Address1->font();
-    font1.setPointSize(font1.pointSize()-1);
-    MemoTxt1->setFont(font1);
+    // Base font (no shrink) so an entered private note is readable.
     MemoTxt1->setWordWrap(true);
     sendAddressLayout->addWidget(MemoTxt1);
 
@@ -338,11 +356,32 @@ void MainWindow::addressChanged(int itemNumber, const QString& text) {
             fld->style()->polish(fld);
         }
     }
+
+    updateSendPrivacyBadge();   // recipient changed -> the private/public verdict may change
+    updateSendTotals();
 }
 
 void MainWindow::amountChanged(int item, const QString& text) {
     auto usd = ui->sendToWidgets->findChild<QLabel*>(QString("AmtUSD") % QString::number(item));
     usd->setText(Settings::getUSDFormat(text.toDouble()));
+
+    // Live amount affordance, mirroring the address border: neutral while empty, green
+    // once it's a positive number, red if it parses to zero/negative. This is a LOCAL
+    // format check only (>0) — it does NOT compare against the balance and does NOT call
+    // doSendTxValidations; the authoritative overspend check stays at Send time.
+    auto* fld = ui->sendToWidgets->findChild<QLineEdit*>(QString("Amount") % QString::number(item));
+    if (fld) {
+        const char* state = text.trimmed().isEmpty() ? "empty"
+                          : (text.toDouble() > 0 ? "valid" : "invalid");
+        if (fld->property("validation").toString() != QString(state)) {
+            fld->setProperty("validation", state);
+            fld->style()->unpolish(fld);
+            fld->style()->polish(fld);
+        }
+    }
+
+    updateSendTotals();   // any amount change updates the running "You will send …" line
+
     // A change to ANOTHER recipient's amount (item != 1) shrinks the max available for
     // recipient 1; recompute it. Guard on item != 1 to avoid recursing on our own setText
     // of Amount1 (which would re-emit amountChanged(1)).
@@ -354,10 +393,10 @@ void MainWindow::setMemoEnabled(int number, bool enabled) {
     auto memoBtn = ui->sendToWidgets->findChild<QPushButton*>(QString("MemoBtn") % QString::number(number));
      if (enabled) {
         memoBtn->setEnabled(true);
-        memoBtn->setToolTip("");
+        memoBtn->setToolTip(tr("Attach an encrypted message only the recipient can read"));
     } else {
         memoBtn->setEnabled(false);
-        memoBtn->setToolTip(tr("Only z-addresses can have memos"));
+        memoBtn->setToolTip(tr("Private notes are only available for z-addresses (private)"));
     }
 }
 
@@ -451,7 +490,9 @@ void MainWindow::memoButtonClicked(int number, bool includeReplyTo) {
         fnAddReplyTo();
 
     if (dialog.exec() == QDialog::Accepted) {
-        memoTxt->setText(memoDialog.memoTxt->toPlainText());
+        QString m = memoDialog.memoTxt->toPlainText().trimmed();
+        // Label the note so the line under the amount reads as a "Private note", not stray text.
+        memoTxt->setText(m.isEmpty() ? QString() : tr("Private note: ") % m);
     }
 }
 
@@ -466,8 +507,10 @@ void MainWindow::removeExtraAddresses() {
     amt->clear();
     auto amtUSD  = ui->sendToWidgets->findChild<QLabel*>(QString("AmtUSD1"));
     amtUSD->clear();
-    auto max  = ui->sendToWidgets->findChild<QCheckBox*>(QString("Max1"));
-    max->setChecked(false);
+    // "Send all" is now a checkable QPushButton (was a QCheckBox) — cast accordingly or
+    // findChild returns null and this null-derefs.
+    auto max  = ui->sendToWidgets->findChild<QPushButton*>(QString("Max1"));
+    if (max) max->setChecked(false);
     auto memo = ui->sendToWidgets->findChild<QLabel*>(QString("MemoTxt1"));
     memo->clear();
 
@@ -488,6 +531,10 @@ void MainWindow::removeExtraAddresses() {
     ui->chkRecurring->setCheckState(Qt::Unchecked);
     ui->btnRecurSchedule->setEnabled(false);
     ui->lblRecurDesc->setText("");
+
+    // Clear the live privacy badge + running totals back to their resting state.
+    updateSendPrivacyBadge();
+    updateSendTotals();
 }
 
 void MainWindow::maxAmountChecked(int checked) {
@@ -1400,7 +1447,96 @@ QString MainWindow::doSendTxValidations(Tx tx) {
 }
 
 void MainWindow::cancelButton() {
+    // Forgiving: don't silently destroy typed work. If the user has started a payment
+    // (a recipient or amount is entered), confirm before clearing the form. An empty
+    // form clears silently. removeExtraAddresses() itself is unchanged.
+    auto* addr = ui->sendToWidgets->findChild<QLineEdit*>("Address1");
+    auto* amt  = ui->sendToWidgets->findChild<QLineEdit*>("Amount1");
+    bool hasInput = (addr && !addr->text().trimmed().isEmpty())
+                 || (amt  && !amt->text().trimmed().isEmpty());
+    if (hasInput) {
+        auto r = QMessageBox::question(this, tr("Discard this payment?"),
+            tr("Your typed recipients and amounts will be cleared."),
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        if (r != QMessageBox::Yes)
+            return;
+    }
     removeExtraAddresses();
+}
+
+// PRESENTATION-ONLY: drive the live private/public verdict badge above the Send form
+// from the wallet's own daemon-free classifier (sendCategoryOf, sendcategory.h). It
+// builds a lightweight ECHO Tx from the on-screen From + recipient addresses and reads
+// the category — it never sends, never touches the spendable/zatoshi math, and the
+// classifier errs toward the stronger public/de-shield verdict on an unparseable
+// address, so it can only over-warn, never under-warn.
+void MainWindow::updateSendPrivacyBadge() {
+    auto* badge = ui->sendPrivacyBadge;
+    if (!badge) return;
+
+    // Gather resolved recipient addresses currently on screen.
+    Tx tx;
+    tx.fromAddr = ui->inputsCombo->currentText();
+    bool anyRecipient = false;
+    QRegExp re("Address[0-9]+", Qt::CaseInsensitive);
+    for (auto* fld : ui->sendToWidgets->findChildren<QLineEdit*>(re)) {
+        QString a = AddressBook::addressFromAddressLabel(fld->text().trimmed());
+        if (a.isEmpty()) continue;
+        anyRecipient = true;
+        ToFields t; t.addr = a; t.amount = 0; tx.toAddrs.push_back(t);
+    }
+
+    QString text, tone;
+    if (!anyRecipient || tx.fromAddr.isEmpty()) {
+        text = tr("Set who you are paying to see if this send is private");
+        tone = QString();   // neutral
+    } else {
+        switch (sendCategoryOf(tx)) {
+        case SendCategory::ZToZ_private:
+            text = tr("● Private — only you and the recipient can see this"); tone = "private"; break;
+        case SendCategory::TToZ_shielding:
+            text = tr("● Shielding — this becomes private"); tone = "private"; break;
+        case SendCategory::TToT_public:
+            text = tr("● Public — the amount and recipient are visible to everyone"); tone = "public"; break;
+        case SendCategory::ZToT_deshield:
+            text = tr("● De-shield — this leaves your private balance and becomes public forever"); tone = "deshield"; break;
+        }
+    }
+    badge->setText(text);
+    badge->setProperty("badge", tone.isEmpty() ? QVariant() : QVariant("true"));
+    badge->setProperty("tone", tone.isEmpty() ? QVariant() : QVariant(tone));
+    badge->style()->unpolish(badge);
+    badge->style()->polish(badge);
+}
+
+// PRESENTATION-ONLY: the running "You will send X + fee Y = Z" line under the fee row.
+// It only AGGREGATES values already on screen (the same read-only findChild loop the
+// max math uses) — it writes nothing, computes no spendable/zatoshi math, and the
+// authoritative total still comes from confirmTx. Hidden until an amount is entered.
+void MainWindow::updateSendTotals() {
+    auto* line = ui->sendTotalsLine;
+    if (!line) return;
+
+    double sum = 0; bool any = false;
+    QRegExp re("Amount[0-9]+", Qt::CaseInsensitive);
+    for (auto* fld : ui->sendToWidgets->findChildren<QLineEdit*>(re)) {
+        QString t = fld->text().trimmed();
+        if (t.isEmpty()) continue;
+        double v = t.toDouble();
+        if (v > 0) { sum += v; any = true; }
+    }
+    if (!any) { line->clear(); return; }
+
+    double fee = ui->minerFeeAmt->text().trimmed().toDouble();
+    double total = sum + fee;
+    QString usd = Settings::getUSDFormat(total);
+    QString msg = tr("You'll send %1 + %2 fee = %3 ZCL")
+                    .arg(Settings::getZCLDisplayFormat(sum))
+                    .arg(Settings::getZCLDisplayFormat(fee))
+                    .arg(Settings::getZCLDisplayFormat(total));
+    if (!usd.isEmpty())
+        msg = msg % "  (~" % usd % ")";
+    line->setText(msg);
 }
 
 // Item 2: calm, NON-blocking "you did it" affirmation shown once a send confirms.

--- a/src/sendtab.cpp
+++ b/src/sendtab.cpp
@@ -490,9 +490,12 @@ void MainWindow::memoButtonClicked(int number, bool includeReplyTo) {
         fnAddReplyTo();
 
     if (dialog.exec() == QDialog::Accepted) {
-        QString m = memoDialog.memoTxt->toPlainText().trimmed();
-        // Label the note so the line under the amount reads as a "Private note", not stray text.
-        memoTxt->setText(m.isEmpty() ? QString() : tr("Private note: ") % m);
+        // MONEY-SAFETY: store the RAW memo only. createTxFromSendPage reads this exact
+        // QLabel verbatim as the on-chain memo (and hex-encodes it), so ANY decoration
+        // here would be SENT on-chain, accumulate on re-edit, and escape the 512-byte
+        // dialog limit. The "private note" framing lives in the button label + tooltips,
+        // never in the payload text.
+        memoTxt->setText(memoDialog.memoTxt->toPlainText());
     }
 }
 

--- a/src/sendtab.cpp
+++ b/src/sendtab.cpp
@@ -99,6 +99,14 @@ void MainWindow::setupSendTab() {
         if (pos == 1) {
             QString txt = ui->minerFeeAmt->text();
             ui->lblMinerFeeUSD->setText(Settings::getUSDFormat(txt.toDouble()));
+            // Re-sync the read-only state + hint each time Send is shown, so toggling
+            // "Allow custom fees" in Settings is reflected without a restart.
+            bool custom = Settings::getInstance()->getAllowCustomFees();
+            ui->minerFeeAmt->setReadOnly(!custom);
+            QString feeHint = custom ? QString()
+                : tr("Default network fee. Turn on “Allow custom fees” in Settings to change it.");
+            ui->minerFeeAmt->setToolTip(feeHint);
+            ui->minerFeeLabel->setToolTip(feeHint);
         }
     });
     //Fees validator


### PR DESCRIPTION
Makes the Send form answer a non-expert's three real questions — **who am I paying, how much total, will the world see this** — *before* the confirm dialog. All changes are in safe seams; the stabilized money/validation logic is byte-for-byte unchanged (verified).

## Highlights
- **Live privacy badge** above the form: 🟢 Private / 🟢 Shielding / 🟠 Public / 🔴 De-shield — a pure display echo of `sendCategoryOf()` (fail-safe: over-warns, never under-warns).
- Plain labels (Pay from / Available to send / Pay to / Network fee / **Review & send**), teaching placeholders, always-on **ZCL** unit, live amount border.
- **Send = green primary** (+Enter); **Cancel is forgiving**; **Send all** button replaces the cryptic Max checkbox (+ fixed a latent `removeExtraAddresses` null-deref the swap exposed).
- Memos discoverable; **running total** line. Docs: `docs/SEND_UX.md`.

## Verification
Built in proot/static-Qt: **L0 104/0, L1 44/0**. Adversarial review (money-safety / widget-correctness / UX-honesty): the 8 protected money functions are **byte-identical**; the checkbox→button swap is mechanically complete; the badge/totals are pure reads.

**Review caught + fixed a real blocker:** an earlier draft prefixed `Private note: ` into the memo *label*, which `createTxFromSendPage` reads verbatim as the on-chain memo — it would have been sent on-chain, doubled on re-edit, and could overflow the 512-byte limit. Reverted to storing the raw memo (now byte-identical to canonical); the framing lives in the button label + tooltips only.

## Deferred (next pass)
Human-readable From-combo items (touches the `(`-split that recovers `tx.fromAddr` — land alone with a round-trip assertion); per-recipient remove; QR-scan; confirm-dialog badge reuse + 'Total leaving / Left after' rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)