### PR TITLE
Receive form: don't-make-me-think UX redesign (presentation-only)

### DIFF
--- a/docs/RECEIVE_UX.md
+++ b/docs/RECEIVE_UX.md
@@ -27,7 +27,7 @@ preserve the privacy-load-bearing spine.
   warning is kept. Privacy is strengthened (badge says "safe to share"; memo disabled for t-addrs),
   never weakened.
 - **URI is parser-safe.** Amount via `getDecimalString` (round-trips through the parser's
-  `toDouble()`); memo **percent-encoded** and appended **only** for a z-address, so it can never
+  `toDouble()`); memo **hex-encoded** (the encoding payZClassicURI decodes) and appended **only** for a z-address, so it can never
   inject a `&`/`=` that would break `payZClassicURI`'s `split('&')`/`split('=')`.
 - **No daemon/RPC/address-creation change** — `addNewZaddr`/`addNewTAddr` untouched; no auto-mint.
 

--- a/docs/RECEIVE_UX.md
+++ b/docs/RECEIVE_UX.md
@@ -1,0 +1,37 @@
+# Receive form — UX redesign ("don't make me think")
+
+Goal: a newcomer should read the Receive tab as one sentence — *"this is my address, it's
+**Private** so it's safe to share, here's a **Copy** that confirms itself, and if I want a
+specific amount I type it and the QR + link carry it."* All changes are presentation-only and
+preserve the privacy-load-bearing spine.
+
+## What changed
+
+| # | Change | Why |
+|---|--------|-----|
+| 1 | **Request amount (+ z-only memo)** bakes a `zclassic:<addr>?amt=&memo=` payment-URI into the QR + a **"Copy payment request"** button | The headline win: answers *"how do they pay the right amount?"* The payer's wallet pre-fills the exact amount — killing the #1 wrong-amount cause. Symmetric to the Send-side `payZClassicURI`, so a scanned request round-trips into Send. |
+| 2 | **"Get paid"** headline + subhead; the private indicator becomes the **shared green badge** (`● Private — safe to share`) matching the Send tab | Answers *"what is this / is it safe to share?"* at rest, in plain words — not just a tooltip. |
+| 3 | **Inline "Copied ✓"** on the Copy button (kept the status-bar message too) | Feedback at the cursor, not 600px away at the window bottom. |
+| 4 | **QR → MEDIUM** error-correction | Scans far more reliably off a screen photo, and keeps the longer payment-URI payload scannable. |
+| 5 | **Calm loading state** (`Preparing your address…`) + disabled actions during warmup | A blank field+QR read as "broken"; never a silent dead-click. |
+| 6 | Visual-parity QSS tokens for the new controls | Receive feels like the same product as the redesigned Send tab. |
+
+## Correctness (the load-bearing constraints)
+- **Address recovery untouched.** Every new affordance reads the **raw** address from
+  `AddressCombo::currentText()` (the `(`-split recovery path) — never re-parsed display text, and
+  nothing is ever written back into the combo. `txtRecieve`'s plain text stays the **exact raw
+  address** (Copy reads it verbatim), so chunking was deliberately **rejected** — readability
+  comes from layout, not inserted spaces.
+- **Private-by-default IA preserved.** Sapling z rests in front; t-Addr + legacy Sprout + Export
+  key stay behind the collapsed *"Other address types (advanced)"* disclosure; the amber t-PUBLIC
+  warning is kept. Privacy is strengthened (badge says "safe to share"; memo disabled for t-addrs),
+  never weakened.
+- **URI is parser-safe.** Amount via `getDecimalString` (round-trips through the parser's
+  `toDouble()`); memo **percent-encoded** and appended **only** for a z-address, so it can never
+  inject a `&`/`=` that would break `payZClassicURI`'s `split('&')`/`split('=')`.
+- **No daemon/RPC/address-creation change** — `addNewZaddr`/`addNewTAddr` untouched; no auto-mint.
+
+## Deferred (next pass)
+- Click-to-copy on the address field + monospace "hero" presentation (via a *separate* display
+  label so `txtRecieve` stays the raw address).
+- "Save QR image…" PNG export; persisting/clearing the last request amount; New-address tooltip.

--- a/res/styles/dark.qss
+++ b/res/styles/dark.qss
@@ -378,6 +378,25 @@ QPushButton#btnReceiveCopy {
 QPushButton#btnReceiveCopy:hover   { background-color: #2a9d2a; border-color: #2a9d2a; }
 QPushButton#btnReceiveCopy:pressed { background-color: #1a6b1a; }
 
+/* "Copy payment request" — same primary-green as Copy (shown only when an amount is set). */
+QPushButton#btnReceiveCopyRequest {
+    background-color: #1f7a1f; color: #ffffff;
+    border: 1px solid #1f7a1f; border-radius: 8px;
+    padding: 10px 18px; font-size: 12pt; font-weight: 700;
+    min-height: 24px;
+}
+QPushButton#btnReceiveCopyRequest:hover   { background-color: #2a9d2a; border-color: #2a9d2a; }
+QPushButton#btnReceiveCopyRequest:pressed { background-color: #1a6b1a; }
+
+/* "Get paid" headline + subhead (plain-language framing, parity with the Send tab). */
+QLabel#lblReceiveHeadline { font-size: 16pt; font-weight: 700; color: #e6e6e6; }
+QLabel#lblReceiveSubhead  { color: #9aa0a6; }
+
+/* Request-amount inputs — right-aligned amount, same border/radius as the Send fields. */
+QLineEdit#txtReceiveAmount, QLineEdit#txtReceiveMemo {
+    border: 1px solid #3a3f4b; border-radius: 6px; padding: 6px 8px;
+}
+
 QLabel#lblReceiveAddressCaption {
     color: #9aa0a6;
     font-size: 11pt;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3303,7 +3303,13 @@ QString MainWindow::buildReceivePaymentUri() {
     if (txtReceiveMemo && Settings::isZAddress(addr)) {
         QString memo = txtReceiveMemo->text().trimmed();
         if (!memo.isEmpty())
-            uri = uri % QStringLiteral("&memo=") % QString::fromUtf8(QUrl::toPercentEncoding(memo));
+            // HEX-encode the memo: that is the encoding payZClassicURI actually decodes (it
+            // hex-decodes a `^[0-9A-F]+$` memo value), so the text round-trips back to the
+            // payer EXACTLY. Hex is also injection-safe — only [0-9a-f], never a raw '&'/'='
+            // that could break the parser's split('&')/split('=') arity. (Percent-encoding
+            // would NOT round-trip: the parser never percent-decodes, and an all-hex plain
+            // memo like "2024" would be mis-hex-decoded.)
+            uri = uri % QStringLiteral("&memo=") % QString::fromUtf8(memo.toUtf8().toHex());
     }
     return uri;
 }
@@ -3466,11 +3472,12 @@ void MainWindow::setupReceivePrivacyDisclosure() {
         btnCopy->setToolTip(tr("Copy this address to the clipboard"));
         QObject::connect(btnCopy, &QPushButton::clicked, [this, btnCopy]() {
             QString addr = ui->txtRecieve->toPlainText().trimmed();
-            if (addr.isEmpty())
+            if (!Settings::isValidAddress(addr))
                 addr = ui->listRecieveAddresses->currentText();
-            if (addr.isEmpty()) {
-                // NO-FEEDBACK FIX: during the brief address-refresh window the field is empty;
-                // the most prominent Receive button must not be a silent no-op. Say so.
+            // Guard on VALIDITY, not just non-emptiness: during the warmup window txtRecieve
+            // holds the "Preparing your address…" placeholder (non-empty), which must never be
+            // copied as if it were an address.
+            if (!Settings::isValidAddress(addr)) {
                 ui->statusBar->showMessage(tr("No address to copy yet"), 3 * 1000);
                 return;
             }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3262,13 +3262,18 @@ void MainWindow::setupRecieveTab() {
         QOverload<int>::of(&QComboBox::currentIndexChanged), [=] (int index) {
         QString addr = ui->listRecieveAddresses->itemText(index);
         if (addr.isEmpty()) {
-            ui->txtRecieve->clear();
+            // Calm loading state instead of a blank field+QR (reads as "broken"); the
+            // copy/request controls are disabled by updateReceiveQRandPayload() so the
+            // page never offers a silent dead-click during the warmup window.
+            ui->txtRecieve->setPlainText(tr("Preparing your address…"));
             ui->qrcodeDisplay->clear();
+            updateReceiveQRandPayload();
             return;
         }
 
+        // txtRecieve's plain text MUST stay the exact raw address — Copy reads it verbatim.
         ui->txtRecieve->setPlainText(addr);
-        ui->qrcodeDisplay->setQrcodeString(addr);
+        updateReceiveQRandPayload();   // builds the QR (bare addr, or zclassic: URI if amount set)
     });
 
     // Phase-3c: private-by-default IA. Build the disclosure LAST so it can reparent
@@ -3278,6 +3283,54 @@ void MainWindow::setupRecieveTab() {
     // also frames the QR (P0-5), adds the primary Copy button (P1/UX-24), and hangs
     // the demoted "Export private key" action behind the advanced panel (P0-4).
     setupReceivePrivacyDisclosure();
+}
+
+// Build the optional zclassic: payment-request URI for the SELECTED receive address from the
+// request-amount (+ z-only memo) fields. Returns "" when no amount is set (caller then uses the
+// bare address). CORRECTNESS: the address is the RAW value recovered by AddressCombo::currentText()
+// (the '(' split), never re-parsed display text; the amount goes through getDecimalString so it
+// round-trips through the Send-side parser's toDouble(); the memo is PERCENT-ENCODED and appended
+// ONLY for a z-address, so it can never inject a '&'/'=' that would break payZClassicURI's
+// arg.split('&')/kv.split('=') (which require exactly-2 parts) and matches the parser's t-addr
+// memo-drop. This is the symmetric inverse of payZClassicURI — a scanned request re-enters Send.
+QString MainWindow::buildReceivePaymentUri() {
+    if (!txtReceiveAmount) return QString();
+    QString addr = ui->listRecieveAddresses->currentText();   // raw addr (combo '(' split)
+    if (addr.isEmpty()) return QString();
+    double amt = txtReceiveAmount->text().trimmed().toDouble();
+    if (amt <= 0) return QString();                            // no amount -> no request URI
+    QString uri = QStringLiteral("zclassic:") % addr % QStringLiteral("?amt=") % Settings::getDecimalString(amt);
+    if (txtReceiveMemo && Settings::isZAddress(addr)) {
+        QString memo = txtReceiveMemo->text().trimmed();
+        if (!memo.isEmpty())
+            uri = uri % QStringLiteral("&memo=") % QString::fromUtf8(QUrl::toPercentEncoding(memo));
+    }
+    return uri;
+}
+
+// Refresh the Receive QR + the request-payload affordances from the current address + request
+// fields. Presentation only — never mutates the combo or txtRecieve's raw-address plain text.
+void MainWindow::updateReceiveQRandPayload() {
+    QString addr = ui->listRecieveAddresses->currentText();   // raw addr
+    bool haveAddr = !addr.isEmpty();
+    bool isZ = haveAddr && Settings::isZAddress(addr);
+
+    // Memo is only deliverable to a shielded (z) address.
+    if (txtReceiveMemo) {
+        txtReceiveMemo->setEnabled(haveAddr && isZ);
+        txtReceiveMemo->setToolTip(isZ ? QString()
+            : tr("Memos are only delivered to shielded (z) addresses."));
+    }
+    // Never a silent dead-click during warmup: disable the actions until an address is ready.
+    if (txtReceiveAmount) txtReceiveAmount->setEnabled(haveAddr);
+
+    QString uri = buildReceivePaymentUri();
+    bool haveRequest = !uri.isEmpty();
+    if (btnReceiveCopyRequest) btnReceiveCopyRequest->setVisible(haveRequest);
+
+    if (!haveAddr) { ui->qrcodeDisplay->clear(); return; }
+    // Bake the amount/memo into the QR when a request is set; else the bare address.
+    ui->qrcodeDisplay->setQrcodeString(haveRequest ? uri : addr);
 }
 
 // Phase-3c (Quiet+): restructure the Receive page so it is PRIVATE BY DEFAULT.
@@ -3301,13 +3354,23 @@ void MainWindow::setupReceivePrivacyDisclosure() {
     // first view; relabel it to something privacy-forward.
     ui->groupBox_6->setTitle(tr("Receive privately"));
 
-    // ---- 1) Green PRIVATE indicator (the resting-state affordance) ----------
+    // ---- 0) Plain-language "Get paid" framing (the at-rest answer to "what is this?") --
+    auto* lblReceiveHeadline = new QLabel(tr("Get paid"), ui->groupBox_6);
+    lblReceiveHeadline->setObjectName("lblReceiveHeadline");
+    auto* lblReceiveSubhead = new QLabel(tr("Share the address below to receive ZCL."), ui->groupBox_6);
+    lblReceiveSubhead->setObjectName("lblReceiveSubhead");
+    lblReceiveSubhead->setWordWrap(true);
+
+    // ---- 1) Green PRIVATE indicator — the shared badge pill (Send-tab parity) -------
     lblReceivePrivate = new QLabel(ui->groupBox_6);
-    lblReceivePrivate->setObjectName("lblReceivePrivate");   // qss hook (green badge)
-    // P2-8: lead the caption with "Private"; the "shielded (z)" technical detail
-    // lives in the tooltip only, so the standalone label stays in plain user words.
-    lblReceivePrivate->setText(tr("●  Private address"));
+    lblReceivePrivate->setObjectName("lblReceivePrivate");   // qss hook
+    // Answer "is this safe to share publicly?" right on the resting line (today only in a
+    // tooltip). Use the standardized green badge tokens so Receive matches Send. The
+    // "shielded (z) Sapling" technical detail stays in the tooltip, plain words on the line.
+    lblReceivePrivate->setText(tr("●  Private — safe to share"));
     lblReceivePrivate->setTextFormat(Qt::PlainText);
+    lblReceivePrivate->setProperty("badge", "true");
+    lblReceivePrivate->setProperty("tone", "private");
     lblReceivePrivate->setToolTip(tr(
         "This is a shielded (z) Sapling address. The amount, sender and recipient are "
         "encrypted on the blockchain — private by default."));
@@ -3401,7 +3464,7 @@ void MainWindow::setupReceivePrivacyDisclosure() {
         btnCopy->setObjectName("btnReceiveCopy");
         btnCopy->setCursor(Qt::PointingHandCursor);
         btnCopy->setToolTip(tr("Copy this address to the clipboard"));
-        QObject::connect(btnCopy, &QPushButton::clicked, [this]() {
+        QObject::connect(btnCopy, &QPushButton::clicked, [this, btnCopy]() {
             QString addr = ui->txtRecieve->toPlainText().trimmed();
             if (addr.isEmpty())
                 addr = ui->listRecieveAddresses->currentText();
@@ -3413,6 +3476,11 @@ void MainWindow::setupReceivePrivacyDisclosure() {
             }
             QGuiApplication::clipboard()->setText(addr);
             ui->statusBar->showMessage(tr("Address copied to clipboard"), 3 * 1000);
+            // Inline confirmation right at the cursor (the status bar is far at the window
+            // bottom). `this` is the singleShot context so the restore is cancelled if the
+            // window dies first (btnCopy is its child).
+            btnCopy->setText(tr("Copied ✓"));
+            QTimer::singleShot(1500, this, [btnCopy]() { btnCopy->setText(tr("Copy")); });
         });
         if (auto* combaRow = qobject_cast<QHBoxLayout*>(ui->horizontalLayout_10)) {
             // Insert Copy right after the combo (index 1), before New Address.
@@ -3452,13 +3520,64 @@ void MainWindow::setupReceivePrivacyDisclosure() {
         recvRow->addLayout(qrCol);
     }
 
+    // ---- 3b) REQUEST AMOUNT (optional) — the idiotproof "they pay the right amount" flow.
+    // An optional amount (+ z-only memo) bakes a zclassic:<addr>?amt=&memo= payment-URI into
+    // the QR + a "Copy payment request" action, so the payer's wallet pre-fills the exact
+    // amount. The URI grammar is symmetric with payZClassicURI (the Send-side parser), so a
+    // scanned/pasted request round-trips straight into Send. The address is always the RAW
+    // value (never re-parsed display text); the memo is percent-encoded so it can't inject a
+    // '&'/'=' that would break the parser; amount goes through getDecimalString.
+    auto* reqRow = new QHBoxLayout();
+    auto* lblReqCap = new QLabel(tr("Request amount (optional)"), ui->groupBox_6);
+    lblReqCap->setObjectName("lblReceiveAddressCaption");   // reuse the dim caption style
+    txtReceiveAmount = new QLineEdit(ui->groupBox_6);
+    txtReceiveAmount->setObjectName("txtReceiveAmount");
+    txtReceiveAmount->setPlaceholderText(tr("0.00"));
+    txtReceiveAmount->setAlignment(Qt::AlignRight);
+    txtReceiveAmount->setValidator(new QRegExpValidator(QRegExp("[0-9]{0,8}\\.?[0-9]{0,8}"), this));
+    txtReceiveAmount->setMaximumWidth(140);
+    auto* lblReqUnit = new QLabel(tr("ZCL"), ui->groupBox_6);
+    txtReceiveMemo = new QLineEdit(ui->groupBox_6);
+    txtReceiveMemo->setObjectName("txtReceiveMemo");
+    txtReceiveMemo->setPlaceholderText(tr("Add a note for the sender (optional)"));
+    reqRow->addWidget(lblReqCap);
+    reqRow->addWidget(txtReceiveAmount);
+    reqRow->addWidget(lblReqUnit);
+    reqRow->addWidget(txtReceiveMemo);
+    // Rebuild the QR/payload live as the amount/memo change.
+    QObject::connect(txtReceiveAmount, &QLineEdit::textChanged, this, [this](const QString&){ updateReceiveQRandPayload(); });
+    QObject::connect(txtReceiveMemo,   &QLineEdit::textChanged, this, [this](const QString&){ updateReceiveQRandPayload(); });
+
+    // "Copy payment request" — copies the same zclassic: URI; hidden until an amount is set.
+    btnReceiveCopyRequest = new QPushButton(tr("Copy payment request"), ui->groupBox_6);
+    btnReceiveCopyRequest->setObjectName("btnReceiveCopyRequest");
+    btnReceiveCopyRequest->setCursor(Qt::PointingHandCursor);
+    btnReceiveCopyRequest->setVisible(false);
+    QObject::connect(btnReceiveCopyRequest, &QPushButton::clicked, this, [this]() {
+        QString uri = buildReceivePaymentUri();
+        if (uri.isEmpty()) return;
+        QGuiApplication::clipboard()->setText(uri);
+        ui->statusBar->showMessage(tr("Payment request copied to clipboard"), 3 * 1000);
+        btnReceiveCopyRequest->setText(tr("Copied ✓"));
+        QTimer::singleShot(1500, this, [this]() { btnReceiveCopyRequest->setText(tr("Copy payment request")); });
+    });
+    if (auto* combaRow = qobject_cast<QHBoxLayout*>(ui->horizontalLayout_10))
+        combaRow->addWidget(btnReceiveCopyRequest);
+
     // ---- 4) Splice everything in ABOVE the address-combo row ----------------
     // groupLayout currently: [0]=horizontalLayout_9 (now-empty radios row),
     // [1]=horizontalLayout_10 (combo + New Address), [2]=lblSproutWarning.
-    // Insert: badge, advanced-toggle, advanced-panel at the very top (in order).
-    groupLayout->insertWidget(0, lblReceivePrivate);
-    groupLayout->insertWidget(1, btnReceiveAdvanced);
-    groupLayout->insertWidget(2, receiveAdvancedPanel);
+    // Insert (top to bottom): headline, subhead, badge, advanced-toggle, advanced-panel,
+    // then the request-amount row just above the address+QR area.
+    groupLayout->insertWidget(0, lblReceiveHeadline);
+    groupLayout->insertWidget(1, lblReceiveSubhead);
+    groupLayout->insertWidget(2, lblReceivePrivate);
+    groupLayout->insertWidget(3, btnReceiveAdvanced);
+    groupLayout->insertWidget(4, receiveAdvancedPanel);
+    // Place the request-amount row just after the public/sprout warning (i.e. directly
+    // above the address+QR area), or at the end if the warning isn't in this layout.
+    int warnIdx = groupLayout->indexOf(ui->lblSproutWarning);
+    groupLayout->insertLayout(warnIdx >= 0 ? warnIdx + 1 : groupLayout->count(), reqRow);
 
     // ---- 5) Wire the toggle -------------------------------------------------
     QObject::connect(btnReceiveAdvanced, &QToolButton::toggled, [=](bool checked) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -143,6 +143,11 @@ public:
     QToolButton*        btnReceiveAdvanced    = nullptr;   // "▸ Other address types (advanced)"
     QWidget*            receiveAdvancedPanel  = nullptr;   // collapsible container for the radios
     QLabel*             lblReceivePrivate     = nullptr;   // green "Private — shielded (z) address" badge
+    // Request-amount affordances (the zclassic: payment-URI flow). Built in
+    // setupReceivePrivacyDisclosure(); read by updateReceiveQRandPayload/buildReceivePaymentUri.
+    QLineEdit*          txtReceiveAmount      = nullptr;   // optional "Request amount"
+    QLineEdit*          txtReceiveMemo        = nullptr;   // optional z-only note for the sender
+    QPushButton*        btnReceiveCopyRequest = nullptr;   // "Copy payment request" (shown when amount>0)
     bool                receiveAdvancedExpanded = false;
 
     QLabel*             statusLabel;
@@ -482,6 +487,9 @@ private:
     // Built programmatically (no structural .ui churn); reuses lblSproutWarning
     // for the red PUBLIC caption exactly as before.
     void setupReceivePrivacyDisclosure();
+    // Receive payment-request helpers (presentation only; never mutate the combo / raw address).
+    QString buildReceivePaymentUri();   // zclassic:<addr>?amt=&memo= or "" when no amount set
+    void    updateReceiveQRandPayload();
     // Show/hide the advanced disclosure panel; keeps the toggle arrow + collapsed
     // state in sync and, when collapsing, returns to the private (Sapling) view.
     void setReceiveAdvancedExpanded(bool expanded);

--- a/src/qrcodelabel.cpp
+++ b/src/qrcodelabel.cpp
@@ -62,7 +62,9 @@ void QRCodeLabel::setQrcodeString(QString stra) {
     qrModules.clear();
     qrSize = 0;
     if(!str.isEmpty()) {
-        qrcodegen::QrCode qr = qrcodegen::QrCode::encodeText(str.toUtf8().constData(), qrcodegen::QrCode::Ecc::LOW);
+        // MEDIUM error-correction (15%): scans far more reliably off a screen photo than
+        // LOW, and keeps the longer zclassic:?amt=&memo= payment-request payload scannable.
+        qrcodegen::QrCode qr = qrcodegen::QrCode::encodeText(str.toUtf8().constData(), qrcodegen::QrCode::Ecc::MEDIUM);
         qrSize = qr.getSize() > 0 ? qr.getSize() : 0;
         if(qrSize > 0) {
             qrModules.resize(qrSize * qrSize);


### PR DESCRIPTION
Completes the Send/Receive pair. Makes the Receive tab read as one sentence: *this is my address, it's **Private** so safe to share, **Copy** confirms itself, and I can request a specific amount.* Presentation-only; the privacy-by-default IA and the AddressCombo address-recovery are preserved.

## Highlights
- **Request amount (+ z-only memo)** bakes a `zclassic:<addr>?amt=&memo=` payment-URI into the QR + a **Copy payment request** button — the payer's wallet pre-fills the exact amount. Symmetric to `payZClassicURI`, so a scanned request round-trips into Send.
- **"Get paid"** framing + the shared green **"Private — safe to share"** badge (Send-tab parity); **inline "Copied ✓"**; QR → **MEDIUM** ECC; calm **"Preparing…"** loading state (never a dead-click).

## Verification
Built green **L0 104/0, L1 44/0**. Adversarial review (address-recovery / URI round-trip / privacy-IA) confirmed: the address copied/QR'd/baked-into-a-URI is **always the exact raw address**; privacy IA preserved/strengthened. It caught + I fixed two non-blockers: Copy could grab the "Preparing…" placeholder (now validity-guarded), and the memo is now **hex-encoded** (what `payZClassicURI` decodes) so it round-trips exactly + stays injection-safe.

Docs: `docs/RECEIVE_UX.md`. Deferred: click-to-copy/monospace address hero, Save-QR PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)