### PR TITLE
beta7: Coin Control dialog (transparent + shielded note visibility/selection)

### DIFF
--- a/src/balancestablemodel.h
+++ b/src/balancestablemodel.h
@@ -16,6 +16,25 @@ struct UnspentOutput {
     // basis must EXCLUDE these. C++14 default member init keeps this an aggregate,
     // so existing brace-initializers without the field still compile (coinbase=false).
     bool    coinbase = false;
+
+    // COIN CONTROL — the per-output coordinates the daemon needs to pin THIS exact
+    // input in a typed z_sendmany inputs array. ALL default-initialized so this stays a
+    // C++14 brace-init aggregate (every existing UnspentOutput{...} initializer that
+    // omits them still compiles). They carry NO money math and are written ONLY by
+    // RPC::processUnspent from the daemon's own listunspent / z_listunspent reply:
+    //   * transparent (listunspent):  vout       (the output index)
+    //   * Sapling     (z_listunspent): outindex  (the note's output index)
+    //   * Sprout      (z_listunspent): jsindex + jsoutindex (the JoinSplit coords)
+    // A field stays -1 when it does not apply to the row's pool, so the typed-inputs
+    // builder picks the right key set per type. `change` mirrors z_listunspent's
+    // "change" flag (true => this note is wallet change), surfaced read-only in the
+    // Coin Control table's Change? column. These never alter selection/affordability
+    // logic; they are pure pass-through coordinates + display metadata.
+    int     vout      = -1;     // transparent output index
+    int     outindex  = -1;     // Sapling note output index
+    int     jsindex   = -1;     // Sprout JoinSplit index
+    int     jsoutindex= -1;     // Sprout JoinSplit output index
+    bool    change    = false;  // z_listunspent "change": this note is wallet change
 };
 
 class BalancesTableModel : public QAbstractTableModel

--- a/src/coincontroldialog.cpp
+++ b/src/coincontroldialog.cpp
@@ -1,0 +1,205 @@
+#include "coincontroldialog.h"
+#include "ui_coincontroldialog.h"
+#include "rpc.h"
+#include "settings.h"
+#include "balancestablemodel.h"
+
+#include <QTableWidget>
+#include <QTableWidgetItem>
+#include <QHeaderView>
+#include <QHBoxLayout>
+#include <QCheckBox>
+
+// Convert a <=8-decimal-place ZCL amount string to integer zatoshis. Mirrors
+// sendtab.cpp's toZat(): the UnspentOutput amount is the daemon's own FormatMoney
+// decimal string, so llround is exact within MAX_MONEY (no half-zatoshi tie). Money is
+// summed in integer zatoshis so the coverage readout never drifts by IEEE-754 dust.
+static inline qint64 ccToZat(const QString& amountStr) {
+    return static_cast<qint64>(llround(amountStr.toDouble() * 1e8));
+}
+
+// Pool label for the Type column + the SelectedInput.type the daemon needs. Derived
+// from the address (the wallet's own classifier) so a row's type is single-sourced.
+static QString ccTypeOf(const QString& addr) {
+    if (Settings::isTAddress(addr))                          return "transparent";
+    if (Settings::getInstance()->isSaplingAddress(addr))     return "sapling";
+    if (Settings::getInstance()->isSproutAddress(addr))      return "sprout";
+    // Fallback: a z-address we couldn't finely classify. Treat as sapling for display
+    // only (selection of such a row stays gated behind allowShielded). Never affects
+    // money math — the typed-inputs builder keys off this string but the daemon
+    // validates the coordinates regardless.
+    return Settings::isZAddress(addr) ? "sapling" : "transparent";
+}
+
+CoinControlDialog::CoinControlDialog(QWidget* parent, RPC* rpc, const QString& fromAddr,
+                                     qint64 targetZat, bool allowShielded,
+                                     const QList<SelectedInput>& initial)
+    : parent(parent), rpc(rpc), fromAddr(fromAddr), targetZat(targetZat),
+      allowShielded(allowShielded), initial(initial) {}
+
+// Column layout for the inputs table.
+enum CcCol { CC_CHECK = 0, CC_ADDRESS, CC_AMOUNT, CC_CONFS, CC_TYPE, CC_CHANGE, CC_NCOLS };
+
+bool CoinControlDialog::exec() {
+    Ui_CoinControlDialog cc;
+    QDialog dialog(parent);
+    cc.setupUi(&dialog);
+    Settings::saveRestore(&dialog);
+
+    QTableWidget* tbl = cc.inputsTable;
+    tbl->setColumnCount(CC_NCOLS);
+    QStringList headers;
+    headers << QObject::tr("Use") << QObject::tr("Address") << QObject::tr("Amount")
+            << QObject::tr("Confirmations") << QObject::tr("Type") << QObject::tr("Change?");
+    tbl->setHorizontalHeaderLabels(headers);
+    tbl->verticalHeader()->setVisible(false);
+    tbl->horizontalHeader()->setSectionResizeMode(CC_ADDRESS, QHeaderView::Stretch);
+
+    // Build the candidate row list = the wallet's CONFIRMED, spendable UTXOs/notes for
+    // the chosen from-address. We mirror the send guards' confirmed (confirmations > 0)
+    // + spendable filter so the dialog can never offer an input the daemon would reject.
+    // We hold a parallel UnspentOutput list so we can read back each checked row's exact
+    // coordinates + integer-zatoshi value (the row carries an index into it).
+    QList<UnspentOutput> rows;
+    if (rpc && rpc->getUTXOs()) {
+        for (const UnspentOutput& u : *rpc->getUTXOs()) {
+            if (u.address == fromAddr && u.confirmations > 0 && u.spendable)
+                rows.append(u);
+        }
+    }
+
+    tbl->setRowCount(rows.size());
+
+    // Pre-checked set: anything in `initial` (a re-open) whose coordinates still match a
+    // live row. We compare on (txid, type, index, jsindex) — the exact key the daemon
+    // pins on — so a since-spent input simply drops out of the restored selection.
+    auto isInitiallyChecked = [&](const UnspentOutput& u, const QString& type, int index, int jsindex) -> bool {
+        for (const SelectedInput& s : initial) {
+            if (s.txid == u.txid && s.type == type && s.index == index && s.jsindex == jsindex)
+                return true;
+        }
+        return false;
+    };
+
+    // The checkbox lives inside a centered cell-widget wrapper, so reading it back is
+    // always cellWidget()->findChild<QCheckBox*>() (NOT a direct cast of cellWidget()).
+    auto fnCellCheck = [tbl](int r) -> QCheckBox* {
+        QWidget* w = tbl->cellWidget(r, CC_CHECK);
+        return w ? w->findChild<QCheckBox*>() : nullptr;
+    };
+
+    // running coverage readout: re-summed from the checkboxes on every toggle.
+    auto fnUpdateSummary = [=]() {
+        qint64 sumZat = 0;
+        for (int r = 0; r < tbl->rowCount(); r++) {
+            auto* chk = fnCellCheck(r);
+            if (chk && chk->isChecked()) {
+                // amountZat is stashed on the checkbox via a dynamic property so the
+                // sum reads the SAME integer zatoshi value parsed at build time (no
+                // re-parse drift).
+                sumZat += chk->property("amountZat").toLongLong();
+            }
+        }
+
+        QString sumStr = Settings::getZCLDisplayFormat((double)sumZat / 1e8);
+        if (sumZat == 0) {
+            cc.lblSummary->setText(QObject::tr("No inputs selected — the wallet will choose for you."));
+            cc.lblSummary->setStyleSheet("");
+        } else if (targetZat <= 0) {
+            // No known send target yet (amount/fee not entered). Show the sum only.
+            cc.lblSummary->setText(QObject::tr("Selected: %1").arg(sumStr));
+            cc.lblSummary->setStyleSheet("");
+        } else {
+            QString tgtStr = Settings::getZCLDisplayFormat((double)targetZat / 1e8);
+            if (sumZat >= targetZat) {
+                cc.lblSummary->setText(QObject::tr("Selected: %1  ✓ covers %2 (amount + fee)")
+                                       .arg(sumStr).arg(tgtStr));
+                cc.lblSummary->setStyleSheet("color: green;");
+            } else {
+                cc.lblSummary->setText(QObject::tr("Selected: %1  — NOT enough for %2 (amount + fee)")
+                                       .arg(sumStr).arg(tgtStr));
+                cc.lblSummary->setStyleSheet("color: red;");
+            }
+        }
+    };
+
+    for (int r = 0; r < rows.size(); r++) {
+        const UnspentOutput& u = rows[r];
+        const QString type = ccTypeOf(u.address);
+        const bool isShielded = (type != "transparent");
+
+        // Resolve the daemon coordinates per pool (see SelectedInput / processUnspent).
+        int index   = -1;
+        int jsindex = -1;
+        if (type == "transparent")  { index = u.vout; }
+        else if (type == "sapling") { index = u.outindex; }
+        else /* sprout */           { index = u.jsoutindex; jsindex = u.jsindex; }
+
+        const qint64 amtZat = ccToZat(u.amount);
+
+        // Col 0: the checkbox, hosted in a centered cell widget. Shielded rows are
+        // checkable ONLY when allowShielded (the Advanced manual-note opt-in); otherwise
+        // the row is shown for VISIBILITY but disabled (auto-selection stays privacy-
+        // optimized). The integer-zatoshi value rides as a dynamic property so the
+        // coverage sum never re-parses.
+        auto* chk = new QCheckBox();
+        chk->setProperty("amountZat", (qlonglong)amtZat);
+        bool checkable = !isShielded || allowShielded;
+        chk->setEnabled(checkable);
+        chk->setChecked(checkable && isInitiallyChecked(u, type, index, jsindex));
+        if (isShielded && !allowShielded)
+            chk->setToolTip(QObject::tr("Turn on \"manual shielded note selection\" in "
+                                        "Settings to pick individual shielded notes. "
+                                        "Auto-selection is privacy-optimized."));
+        QObject::connect(chk, &QCheckBox::toggled, [=](bool) { fnUpdateSummary(); });
+
+        auto* cellW = new QWidget();
+        auto* cellL = new QHBoxLayout(cellW);
+        cellL->addWidget(chk);
+        cellL->setAlignment(Qt::AlignCenter);
+        cellL->setContentsMargins(0, 0, 0, 0);
+        tbl->setCellWidget(r, CC_CHECK, cellW);
+
+        auto fnReadOnlyItem = [](const QString& text) {
+            auto* it = new QTableWidgetItem(text);
+            it->setFlags(it->flags() & ~Qt::ItemIsEditable);   // display-only
+            return it;
+        };
+
+        tbl->setItem(r, CC_ADDRESS, fnReadOnlyItem(u.address));
+        auto* amtItem = fnReadOnlyItem(Settings::getZCLDisplayFormat(u.amount.toDouble()));
+        amtItem->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        tbl->setItem(r, CC_AMOUNT, amtItem);
+        auto* confItem = fnReadOnlyItem(QString::number(u.confirmations));
+        confItem->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        tbl->setItem(r, CC_CONFS, confItem);
+        tbl->setItem(r, CC_TYPE, fnReadOnlyItem(type));
+        tbl->setItem(r, CC_CHANGE, fnReadOnlyItem(u.change ? QObject::tr("yes") : QString()));
+    }
+
+    tbl->resizeColumnsToContents();
+    tbl->horizontalHeader()->setSectionResizeMode(CC_ADDRESS, QHeaderView::Stretch);
+    fnUpdateSummary();
+
+    if (dialog.exec() != QDialog::Accepted)
+        return false;   // Cancel/close: caller leaves the prior selection untouched.
+
+    // Collect the checked rows into the result selection (integer-zatoshi values copied
+    // verbatim from the rows so the send guards size against the exact same numbers).
+    result.clear();
+    for (int r = 0; r < rows.size(); r++) {
+        auto* chk = fnCellCheck(r);
+        if (!chk || !chk->isChecked())
+            continue;
+        const UnspentOutput& u = rows[r];
+        const QString type = ccTypeOf(u.address);
+        int index   = -1;
+        int jsindex = -1;
+        if (type == "transparent")  { index = u.vout; }
+        else if (type == "sapling") { index = u.outindex; }
+        else /* sprout */           { index = u.jsoutindex; jsindex = u.jsindex; }
+
+        result.append(SelectedInput{ type, u.txid, index, jsindex, ccToZat(u.amount) });
+    }
+    return true;
+}

--- a/src/coincontroldialog.h
+++ b/src/coincontroldialog.h
@@ -1,0 +1,54 @@
+#ifndef COINCONTROLDIALOG_H
+#define COINCONTROLDIALOG_H
+
+#include "precompiled.h"
+#include "mainwindow.h"        // SelectedInput
+
+class RPC;
+
+// COIN CONTROL — modal dialog that lets the user pick EXACTLY which already-valid
+// inputs a payment may spend. It is purely a SELECTION restriction over the wallet's
+// own UTXO/note set (RPC::getUTXOs(), populated from the daemon's listunspent +
+// z_listunspent): it NEVER alters tx/note format, fees, change routing, dust, coinbase,
+// turnstile, or any consensus rule. Modeled on the inline memoDialog pattern in
+// sendtab.cpp — constructed on the stack, exec()'d, and the resulting selection read
+// back via selection().
+//
+// Money-safety contract:
+//   * An EMPTY returned selection means "auto-select" — identical to today's behavior.
+//   * Each returned SelectedInput carries only the daemon coordinates (type/txid/
+//     index/jsindex) + the input's confirmed value in INTEGER ZATOSHIS, copied straight
+//     from the UnspentOutput; the dialog does no money arithmetic beyond summing those
+//     integer zatoshis for the live coverage readout.
+//   * Shielded-note rows are display-only (and unchecked) unless the caller passes
+//     allowShieldedSelection=true (gated behind an Advanced opt-in, with a one-time
+//     privacy warning surfaced by the caller before this dialog opens).
+class CoinControlDialog {
+public:
+    // fromAddr  : restrict the listed inputs to this Send-tab "from" address.
+    // targetZat : recipients + fee in integer zatoshis (the coverage bar compares the
+    //             checked sum against this). 0 => no target known yet (no coverage verdict).
+    // allowShielded : enable the checkboxes on shielded (sapling/sprout) rows.
+    // initial   : the selection already on the Tx (re-opening preserves prior choices).
+    CoinControlDialog(QWidget* parent, RPC* rpc, const QString& fromAddr,
+                      qint64 targetZat, bool allowShielded,
+                      const QList<SelectedInput>& initial);
+
+    // Run the modal. Returns true iff the user accepted (OK); false on Cancel/close —
+    // the caller then leaves tx.selectedInputs untouched.
+    bool exec();
+
+    // The user's chosen inputs after an accepted exec(). EMPTY => auto-select.
+    QList<SelectedInput> selection() const { return result; }
+
+private:
+    QWidget* parent;
+    RPC*     rpc;
+    QString  fromAddr;
+    qint64   targetZat;
+    bool     allowShielded;
+    QList<SelectedInput> initial;
+    QList<SelectedInput> result;
+};
+
+#endif // COINCONTROLDIALOG_H

--- a/src/coincontroldialog.ui
+++ b/src/coincontroldialog.ui
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CoinControlDialog</class>
+ <widget class="QDialog" name="CoinControlDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>720</width>
+    <height>460</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Coin Control — choose which inputs to spend</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="lblHelp">
+     <property name="text">
+      <string>Check the inputs you want this payment to spend. Leaving everything unchecked lets the wallet pick inputs for you (recommended).</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="inputsTable">
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="lblSummary">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>CoinControlDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>440</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>459</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>CoinControlDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>440</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>459</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1929,6 +1929,16 @@ void MainWindow::setupSettingsModal() {
         // Auto shielding
         settings.chkAutoShield->setChecked(Settings::getInstance()->getAutoShield());
 
+        // COIN CONTROL (Advanced). Load current toggles. The manual-shielded sub-option
+        // is only meaningful when Coin Control itself is on, so keep it enabled-with-
+        // parent: it's disabled until Coin Control is checked (and re-enabled live).
+        settings.chkCoinControl->setChecked(Settings::getInstance()->getCoinControlEnabled());
+        settings.chkManualShielded->setChecked(Settings::getInstance()->getManualShieldedSelection());
+        settings.chkManualShielded->setEnabled(settings.chkCoinControl->isChecked());
+        QObject::connect(settings.chkCoinControl, &QCheckBox::toggled, [=](bool on) {
+            settings.chkManualShielded->setEnabled(on);
+        });
+
         // Use Tor
         bool isUsingTor = false;
         if (rpc->getConnection() != nullptr) {
@@ -2007,6 +2017,29 @@ void MainWindow::setupSettingsModal() {
 
             // Auto shield
             Settings::getInstance()->setAutoShield(settings.chkAutoShield->isChecked());
+
+            // COIN CONTROL (Advanced). Persist the toggles and refresh the Send-tab
+            // button visibility immediately (it's still ALSO gated on daemon support, so
+            // turning it on does nothing if the node can't honor a pinned input set).
+            Settings::getInstance()->setCoinControlEnabled(settings.chkCoinControl->isChecked());
+
+            // ONE-TIME privacy warning the first time manual shielded-note selection is
+            // turned ON: hand-picking notes can reduce privacy; auto-selection is
+            // privacy-optimized. Persisted so it never nags again.
+            bool wantManualShielded = settings.chkManualShielded->isChecked();
+            bool wasManualShielded  = Settings::getInstance()->getManualShieldedSelection();
+            if (wantManualShielded && !wasManualShielded
+                    && !QSettings().value("coincontrol/shieldedWarned", false).toBool()) {
+                QMessageBox::warning(this, tr("Manual shielded note selection"),
+                    tr("Manually selecting which shielded (z) notes to spend can REDUCE "
+                       "your privacy by revealing which notes you control together. "
+                       "Automatic selection is privacy-optimized.\n\nOnly turn this on if "
+                       "you understand the tradeoff."),
+                    QMessageBox::Ok);
+                QSettings().setValue("coincontrol/shieldedWarned", true);
+            }
+            Settings::getInstance()->setManualShieldedSelection(wantManualShielded);
+            refreshCoinControlVisibility();
 
             // Keep running in the background (tray-resident). Apply immediately
             // so the change takes effect this session, no restart needed.

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -28,6 +28,22 @@ struct ToFields {
     QString encodedMemo;
 };
 
+// COIN CONTROL — one user-pinned input. A LEAN value carrying only the daemon
+// coordinates needed to name an already-valid UTXO/note in a typed z_sendmany inputs
+// array, plus its confirmed value in INTEGER ZATOSHIS (the selection-aware send guards
+// size against this, never a re-derived double). `type` is "transparent" / "sapling" /
+// "sprout"; `index` is the transparent vout OR the Sapling outindex; `jsindex` is the
+// Sprout JoinSplit index (with `index` reused as jsoutindex for that pool). Coin control
+// ONLY restricts which already-valid inputs the wallet offers the daemon -- it never
+// changes tx/note format, fees, change routing, or any consensus rule.
+struct SelectedInput {
+    QString type;        // "transparent" | "sapling" | "sprout"
+    QString txid;
+    int     index;       // transparent vout | sapling outindex | sprout jsoutindex
+    int     jsindex;     // sprout JoinSplit index (-1 for transparent/sapling)
+    qint64  amountZat;   // confirmed value of THIS input, integer zatoshi
+};
+
 // Struct used to represent a Transaction.
 struct Tx {
     QString         fromAddr;
@@ -48,6 +64,15 @@ struct Tx {
     bool   autoShieldFullConsume = false;  // true: no-change full balance spend (check total)
     qint64 builtEligibleZat      = 0;      // confirmedSpendableZat(fromAddr,false) at build time
     qint64 builtTargetZat        = 0;      // recipients (excl. change row) + fee, at build time
+
+    // COIN CONTROL — the user-pinned inputs from the Coin Control dialog. DEFAULT-EMPTY
+    // (the {} keeps Tx a C++14 brace-init aggregate, so the positional Tx{from,to,fee}
+    // brace-inits still compile). EMPTY == today's behavior EXACTLY: the daemon
+    // auto-selects inputs (no inputs array is appended in fillTxJsonParams, the send
+    // guards size against the whole address as before). NON-EMPTY restricts the daemon
+    // to spend ONLY these already-valid inputs -- a selection restriction only, never a
+    // consensus/format/fee/change change.
+    QList<SelectedInput> selectedInputs = {};
 };
 
 // PRIV-11 / UX-12 — the four-way SendCategory enum + the pure free classifier
@@ -119,6 +144,15 @@ public:
     void updateLabels();
     void updateTAddrCombo(bool checked);
     void updateFromCombo();
+
+    // COIN CONTROL — re-evaluate whether the Send-tab "Coin Control…" button is shown:
+    // visible ONLY when BOTH the Advanced opt-in (Settings::getCoinControlEnabled()) is
+    // ON and the connected daemon advertises z_sendmany inputs support
+    // (RPC::coinControlSupported()). PUBLIC so the RPC capability probe can call it on its
+    // completion (and the Settings save calls it too). Safe before the button is built
+    // (no-op). When the feature becomes unavailable it also clears any pending selection,
+    // so a hidden button can never carry a stale pin into a send.
+    void refreshCoinControlVisibility();
 
     Ui::MainWindow*     ui;
 
@@ -424,6 +458,18 @@ private:
     // match the daemon's has-change input set. Null-safe (returns 0 if UTXOs not loaded).
     qint64  confirmedSpendableZat(const QString& addr, bool includeCoinbase);
 
+    // COIN CONTROL selection-aware spendable total. When tx.selectedInputs is non-empty,
+    // the daemon will spend ONLY those inputs, so the auto-shield change + the pre-send
+    // race gate must size against the SELECTED subset, NOT the whole address. Sums (in
+    // integer zatoshis) each selected input that is STILL present in the live UTXO set as
+    // confirmed + spendable (a since-spent/unconfirmed selection drops out, so the total
+    // can only shrink, never assert phantom funds); includeCoinbase=false additionally
+    // excludes coinbase, matching confirmedSpendableZat's contract. allStillSpendable (if
+    // non-null) is set false iff ANY selected input is no longer live-confirmed-spendable,
+    // so the send guards can fail closed before the irrevocable send. Returns 0 if the
+    // UTXO set isn't loaded (caller treats that as "cannot verify").
+    qint64  selectedSpendableZat(const Tx& tx, bool includeCoinbase, bool* allStillSpendable = nullptr);
+
     // FAIL-OPEN spendable accessor (the load-bearing money-safety primitive). Returns the
     // CONFIRMED, spendable balance of `addr` (via confirmedSpendableZat, coinbase-inclusive)
     // ONLY when the UTXO set is actually loaded; otherwise it falls back to the minconf=0
@@ -455,6 +501,22 @@ private:
     void setupTurnstileDialog();
     void turnstileDoMigration(QString fromAddr = "");
     void turnstileProgress();
+
+    // COIN CONTROL — built programmatically in setupSendTab() (no .ui structural change,
+    // same idiom as the nav rail / network help panel). The button sits next to the
+    // from-address combo and opens the Coin Control dialog, which edits the pending
+    // tx.selectedInputs. Hidden unless BOTH the Advanced "Enable Coin Control" setting is
+    // ON and the connected daemon advertises z_sendmany inputs support
+    // (RPC::coinControlSupported()). openCoinControl() runs the dialog; the chosen
+    // selection is held here until the next send and applied to the Tx in
+    // createTxFromSendPage().
+    void setupCoinControlButton();
+    void openCoinControl();
+    QPushButton*         coinControlBtn   = nullptr;
+    // The user's pinned inputs for the NEXT send. Default-empty => auto-select (today's
+    // behavior). Cleared on a successful send (removeExtraAddresses) and whenever the
+    // from-address changes, so a stale selection from another address can never be used.
+    QList<SelectedInput> pendingSelectedInputs = {};
 
     void cancelButton();
     void sendButton();

--- a/src/rpc.cpp
+++ b/src/rpc.cpp
@@ -634,11 +634,45 @@ void RPC::fillTxJsonParams(json& params, Tx tx) {
         allRecepients.push_back(rec);
     }
 
-    // Add sender    
+    // Add sender
     params.push_back(tx.fromAddr.toStdString());
     params.push_back(allRecepients);
 
-    // Add fees if custom fees are allowed.
+    // COIN CONTROL — when the user pinned a specific input set, the typed inputs array
+    // is the 5TH positional z_sendmany argument, so minconf (3rd) and fee (4th) MUST be
+    // present even if custom fees are off (positional args cannot be skipped). We
+    // therefore append minconf=1 + the (default or custom) fee here, then the inputs
+    // array. EMPTY selectedInputs keeps the EXACT legacy shape below: fee/minconf are
+    // appended ONLY when custom fees are on, and no inputs array is added — so the
+    // default-empty path is byte-identical to today's behavior.
+    //
+    // Consensus impact: NONE. The inputs array only restricts which already-valid UTXOs/
+    // notes the daemon may spend; it does not touch tx/note format, validation, fees,
+    // change routing, or any consensus rule. minconf=1 matches z_sendmany's own default,
+    // and tx.fee is the same fee the legacy path sends.
+    if (!tx.selectedInputs.isEmpty()) {
+        params.push_back(1);                          // 3rd: minconf (z_sendmany default)
+        params.push_back(tx.fee);                     // 4th: fee (default or custom)
+
+        json inputs = json::array();
+        for (const SelectedInput& s : tx.selectedInputs) {
+            json in = json::object();
+            in["txid"] = s.txid.toStdString();
+            if (s.type == "transparent") {
+                in["vout"] = s.index;                 // transparent: output index
+            } else if (s.type == "sapling") {
+                in["outindex"] = s.index;             // sapling: note output index
+            } else { // sprout
+                in["jsindex"]    = s.jsindex;         // sprout: JoinSplit index
+                in["jsoutindex"] = s.index;           //         JoinSplit output index
+            }
+            inputs.push_back(in);
+        }
+        params.push_back(inputs);                      // 5th: typed inputs array
+        return;
+    }
+
+    // Legacy path (no coin control): unchanged. Add fee/minconf only with custom fees.
     if (Settings::getInstance()->getAllowCustomFees()) {
         params.push_back(1); // minconf
         params.push_back(tx.fee);
@@ -968,6 +1002,12 @@ void RPC::getInfoThenRefresh(bool force) {
         int curBlock  = reply["blocks"].get<json::number_integer_t>();
         int version = reply["version"].get<json::number_integer_t>();
         Settings::getInstance()->setZClassicdVersion(version);
+
+        // COIN CONTROL — probe the daemon's z_sendmany inputs-param support ONCE per
+        // session (one-shot internally) so the Send-tab Coin Control button is offered
+        // ONLY on a daemon that can honor a pinned input set. Cheap (a single `help`
+        // call) and self-latching; hidden until/unless the probe confirms support.
+        probeCoinControlCapability();
 
         if ( force || (curBlock != lastBlock) ) {
             // Something changed, so refresh everything.
@@ -1470,10 +1510,28 @@ bool RPC::processUnspent(const json& reply, QMap<QString, double>* balancesMap, 
         // is used rather than contains() -- the bundled nlohmann::json 3.3 predates it.)
         bool coinbase = it.find("generated") != it.end() && it["generated"].get<json::boolean_t>();
 
-        newUtxos->push_back(
-            UnspentOutput{ qsAddr, QString::fromStdString(it["txid"]),
-                            Settings::getDecimalString(it["amount"].get<json::number_float_t>()),
-                            (int)confirmations, it["spendable"].get<json::boolean_t>(), coinbase });
+        UnspentOutput uo{ qsAddr, QString::fromStdString(it["txid"]),
+                          Settings::getDecimalString(it["amount"].get<json::number_float_t>()),
+                          (int)confirmations, it["spendable"].get<json::boolean_t>(), coinbase };
+
+        // COIN CONTROL — capture the per-output coordinates straight from the daemon's
+        // own reply so a pinned z_sendmany inputs array can name THIS exact input. Field
+        // sets are disjoint across pools, so we only read the key present for the row's
+        // type and leave the others at their -1/false sentinels. find()/end() (not
+        // contains()) matches the bundled nlohmann::json 3.3. No money math here -- pure
+        // pass-through coordinates + the read-only "change" flag for the table column.
+        if (it.find("vout") != it.end() && it["vout"].is_number())
+            uo.vout = (int)it["vout"].get<json::number_integer_t>();        // transparent (listunspent)
+        if (it.find("outindex") != it.end() && it["outindex"].is_number())
+            uo.outindex = (int)it["outindex"].get<json::number_integer_t>(); // Sapling (z_listunspent)
+        if (it.find("jsindex") != it.end() && it["jsindex"].is_number())
+            uo.jsindex = (int)it["jsindex"].get<json::number_integer_t>();    // Sprout (z_listunspent)
+        if (it.find("jsoutindex") != it.end() && it["jsoutindex"].is_number())
+            uo.jsoutindex = (int)it["jsoutindex"].get<json::number_integer_t>();
+        if (it.find("change") != it.end() && it["change"].is_boolean())
+            uo.change = it["change"].get<json::boolean_t>();
+
+        newUtxos->push_back(uo);
 
         (*balancesMap)[qsAddr] = (*balancesMap)[qsAddr] + it["amount"].get<json::number_float_t>();
     }
@@ -2372,6 +2430,59 @@ QString RPC::getDefaultSaplingAddress() {
 QString RPC::getDefaultTAddress() {
     if (getAllTAddresses()->length() > 0)
         return getAllTAddresses()->at(0);
-    else 
+    else
         return QString();
+}
+
+// COIN CONTROL — one-shot daemon-capability probe (see rpc.h). Fires `help z_sendmany`
+// and parses the synopsis for an `inputs` argument. The stock ZClassic z_sendmany help
+// reads `z_sendmany "fromaddress" [...] ( minconf ) ( fee )` with NO inputs param and
+// rejects params.size() > 4, so this latches coinControlCapable=false there and the
+// Coin Control UI stays hidden -- the spec's fail-safe gate (never silently drop a
+// selection on a daemon that can't honor it). A future daemon that advertises an
+// `inputs` argument flips it on. Conservative: ANY RPC error leaves the capability OFF.
+void RPC::probeCoinControlCapability() {
+    if (coinControlProbed)
+        return;                 // one-shot per session
+    if (conn == nullptr)
+        return;                 // retry on a later poll once connected
+
+    json payload = {
+        {"jsonrpc", "1.0"},
+        {"id", "someid"},
+        {"method", "help"},
+        {"params", {"z_sendmany"}}
+    };
+
+    // Use the error-AWARE doRPC so a transient/failed probe does NOT latch the capability
+    // (it stays un-probed and retries on the next poll); only a clean answer decides.
+    conn->doRPC(payload, [this] (const json& reply) {
+        coinControlProbed = true;
+        // The help RPC returns the method's help string. Look for an `inputs` argument in
+        // the SYNOPSIS / arguments list. We require the token to appear as an argument
+        // (a quoted "inputs" key or an `inputs` arg line), not merely anywhere, so a
+        // mention in prose can't false-enable it. Default OFF if not clearly present.
+        QString help;
+        if (reply.is_string())
+            help = QString::fromStdString(reply.get<std::string>());
+
+        // Accept either the CLI synopsis form `( inputs )` / `[ inputs ]` or the
+        // arguments-list form `"inputs"` (the daemon's standard help layout). Both are
+        // unambiguous markers that z_sendmany takes a 5th inputs argument.
+        const bool hasInputsArg =
+            help.contains("\"inputs\"") ||
+            help.contains("( inputs )") ||
+            help.contains("[ inputs ]") ||
+            help.contains("(inputs)");
+
+        coinControlCapable = hasInputsArg;
+        if (main) {
+            main->logger->write(QString("Coin Control daemon capability: %1")
+                                .arg(coinControlCapable ? "supported" : "not supported"));
+            main->refreshCoinControlVisibility();
+        }
+    }, [this] (QNetworkReply*, const json&) {
+        // Probe failed (warmup/transient). Do NOT latch: leave it un-probed so a later
+        // poll retries; the UI stays hidden meanwhile (coinControlSupported() is false).
+    });
 }

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -186,6 +186,21 @@ public:
     QString getDefaultSaplingAddress();
     QString getDefaultTAddress();
 
+    // COIN CONTROL daemon-capability gate. The Coin Control feature pins inputs via a
+    // 5TH positional z_sendmany argument (a typed `inputs` array). NOT every daemon
+    // supports it (the stock ZClassic z_sendmany rejects params.size() > 4), so we MUST
+    // probe before offering the UI: if the daemon lacks the param we HIDE Coin Control
+    // entirely rather than ever silently dropping the user's selection.
+    //
+    // probeCoinControlCapability() fires `help z_sendmany` ONCE per session and parses
+    // the returned synopsis for an `inputs` argument; the (default-FALSE, fail-safe)
+    // result latches into coinControlCapable and MainWindow::refreshCoinControlVisibility()
+    // is invoked so the Send-tab button appears/disappears accordingly. Probing again is a
+    // no-op once latched. Conservative: any parse ambiguity or RPC error leaves the
+    // capability OFF (Coin Control hidden), never on.
+    void probeCoinControlCapability();
+    bool coinControlSupported() const { return coinControlProbed && coinControlCapable; }
+
     void getAllPrivKeys(const std::function<void(QList<QPair<QString, QString>>)>);
 
     Turnstile*  getTurnstile()  { return turnstile; }
@@ -361,6 +376,13 @@ private:
     // of source. The per-address listunspent join remains the sole owner of the
     // per-address balances model / UTXO set and never touches the hero labels.
     bool                        summaryCapable              = true;
+
+    // COIN CONTROL capability latch (see probeCoinControlCapability()). coinControlProbed
+    // flips true once the one-shot `help z_sendmany` probe has answered; coinControlCapable
+    // is the (fail-safe default FALSE) verdict. coinControlSupported() requires BOTH, so an
+    // un-probed or unsupported daemon keeps the Coin Control UI hidden.
+    bool                        coinControlProbed           = false;
+    bool                        coinControlCapable          = false;
 
     Connection*                 conn                        = nullptr;
     QProcess*                   ezclassicd                     = nullptr;

--- a/src/sendtab.cpp
+++ b/src/sendtab.cpp
@@ -7,6 +7,7 @@
 #include "settings.h"
 #include "rpc.h"
 #include "recurring.h"
+#include "coincontroldialog.h"
 
 using json = nlohmann::json;
 
@@ -135,8 +136,87 @@ void MainWindow::setupSendTab() {
     ui->lblRecurDesc->setVisible(false);
     ui->btnRecurSchedule->setVisible(false);
 
+    // COIN CONTROL — build the (Advanced + daemon-gated) "Coin Control…" button next to
+    // the from-address combo. Hidden by default; refreshCoinControlVisibility() decides.
+    setupCoinControlButton();
+
     // Set the default state for the whole page
     removeExtraAddresses();
+}
+
+// COIN CONTROL — add the "Coin Control…" button into the existing from-address row
+// (horizontalLayout_8, which holds inputsCombo) programmatically, so the checked-in
+// mainwindow.ui is untouched (same idiom as the nav rail / network help panel). Hidden
+// unless both the Advanced setting and daemon support are present.
+void MainWindow::setupCoinControlButton() {
+    if (coinControlBtn)
+        return;   // idempotent
+
+    coinControlBtn = new QPushButton(tr("Coin Control…"), this);
+    coinControlBtn->setObjectName("coinControlBtn");
+    coinControlBtn->setToolTip(tr("Choose exactly which of your confirmed inputs this "
+                                  "payment spends. Advanced; only restricts which valid "
+                                  "inputs are used."));
+    coinControlBtn->setVisible(false);   // refreshCoinControlVisibility() reveals it
+    QObject::connect(coinControlBtn, &QPushButton::clicked, this, &MainWindow::openCoinControl);
+
+    // Place it on the SAME ROW as the from-address combo (horizontalLayout_8 holds
+    // inputsCombo in mainwindow.ui). findChild keeps us off a hard-coded ui->member and
+    // degrades gracefully: if the named row layout isn't found we fall back to the combo's
+    // parent-widget layout so the button is always reachable, never orphaned.
+    if (auto* hl = ui->groupBox_4->findChild<QHBoxLayout*>("horizontalLayout_8")) {
+        hl->addWidget(coinControlBtn);
+    } else if (ui->inputsCombo->parentWidget() && ui->inputsCombo->parentWidget()->layout()) {
+        ui->inputsCombo->parentWidget()->layout()->addWidget(coinControlBtn);
+    }
+
+    refreshCoinControlVisibility();
+}
+
+// COIN CONTROL — show the button ONLY when BOTH the Advanced opt-in is on AND the daemon
+// advertises z_sendmany inputs support. Called from setup, from the Settings save, and
+// from the RPC capability probe's completion. Safe before the button exists (no-op).
+void MainWindow::refreshCoinControlVisibility() {
+    if (!coinControlBtn)
+        return;
+    const bool show = Settings::getInstance()->getCoinControlEnabled()
+                   && rpc && rpc->coinControlSupported();
+    coinControlBtn->setVisible(show);
+    // If the feature is no longer available, drop any pending selection so a hidden
+    // button can never carry a stale pin into the next send (fail-safe to auto-select).
+    if (!show)
+        pendingSelectedInputs.clear();
+}
+
+// COIN CONTROL — open the dialog for the current from-address, seeded with the running
+// amount + fee so it can show live coverage, and with any prior selection preserved.
+void MainWindow::openCoinControl() {
+    QString fromAddr = ui->inputsCombo->currentText();
+    if (fromAddr.isEmpty()) {
+        QMessageBox::information(this, tr("Coin Control"),
+            tr("Choose an address to pay from first, then pick its inputs."),
+            QMessageBox::Ok);
+        return;
+    }
+
+    // Target = recipients (on-screen amounts) + fee, in integer zatoshis. This is a
+    // DISPLAY aid for the coverage readout only; the authoritative affordability /
+    // privacy checks remain in createTxFromSendPage()/the send guards. We read the
+    // on-screen amounts directly (no Tx build) so opening the dialog never triggers the
+    // auto-shield change machinery.
+    qint64 targetZat = 0;
+    QRegExp re("Amount[0-9]+", Qt::CaseInsensitive);
+    for (auto* fld : ui->sendToWidgets->findChildren<QLineEdit*>(re))
+        targetZat += toZat(fld->text().trimmed().toDouble());
+    targetZat += toZat(Settings::getInstance()->getAllowCustomFees()
+                       ? ui->minerFeeAmt->text().toDouble()
+                       : Settings::getMinerFee());
+
+    const bool allowShielded = Settings::getInstance()->getManualShieldedSelection();
+
+    CoinControlDialog dlg(this, rpc, fromAddr, targetZat, allowShielded, pendingSelectedInputs);
+    if (dlg.exec())
+        pendingSelectedInputs = dlg.selection();
 }
 
 void MainWindow::editSchedule() {
@@ -241,6 +321,13 @@ void MainWindow::inputComboTextChanged(int index) {
     recomputeMaxIfChecked();   // from-address changed -> its balance drives the "Send max" amount
     updateSendPrivacyBadge();  // from-address private/public-ness feeds the verdict
     updateSendTotals();
+
+    // COIN CONTROL — a coin-control selection is scoped to ONE from-address (the dialog
+    // filtered by it). Changing the from-address invalidates that pin, so drop it: a
+    // stale selection from another address must never be applied to a send (createTx only
+    // applies pendingSelectedInputs for the CURRENT from-addr, but clearing here keeps the
+    // model honest and avoids surprising the user with an inherited selection).
+    pendingSelectedInputs.clear();
 }
 
     
@@ -546,6 +633,11 @@ void MainWindow::removeExtraAddresses() {
     // Clear the live privacy badge + running totals back to their resting state.
     updateSendPrivacyBadge();
     updateSendTotals();
+
+    // COIN CONTROL — the form is being reset (dispatched send, Cancel, or first setup), so
+    // any pinned input selection no longer applies. Drop it so the NEXT payment starts
+    // from auto-select unless the user opens Coin Control again.
+    pendingSelectedInputs.clear();
 }
 
 void MainWindow::maxAmountChecked(int checked) {
@@ -625,6 +717,19 @@ Tx MainWindow::createTxFromSendPage() {
     tx.fromAddr = ui->inputsCombo->currentText();
     sendChangeToSapling = sendChangeToSapling && Settings::isTAddress(tx.fromAddr);
 
+    // COIN CONTROL — carry the user's pinned inputs onto the Tx, but ONLY when the
+    // feature is actually live (Advanced setting ON + daemon support). The selection is
+    // address-scoped (the dialog filtered by the from-addr and inputComboTextChanged()
+    // clears it on any from-addr change), so an applied selection always matches
+    // tx.fromAddr. EMPTY (the common case) leaves tx.selectedInputs == {} => auto-select,
+    // byte-identical to today. Coin control restricts inputs only; it never changes the
+    // auto-shield change-routing decision below, only the totals it is sized against.
+    if (rpc && rpc->coinControlSupported()
+            && Settings::getInstance()->getCoinControlEnabled()
+            && !pendingSelectedInputs.isEmpty()) {
+        tx.selectedInputs = pendingSelectedInputs;
+    }
+
     // For each addr/amt in the sendTo tab
     int totalItems = ui->sendToWidgets->children().size() - 2;   // The last one is a spacer, so ignore that
     bool   sproutRecipient = false;
@@ -697,8 +802,18 @@ Tx MainWindow::createTxFromSendPage() {
         // has-change send). The coinbase-inclusive total is the affordability ceiling:
         // the daemon CAN spend coinbase, but only to a single zaddr with full
         // consumption (no change), so it is fundable even when not "eligible" for change.
-        const qint64 eligibleZat       = confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/false);
-        const qint64 confirmedTotalZat = confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/true);
+        //
+        // COIN CONTROL — when the user pinned inputs the daemon spends ONLY those, so we
+        // size the change against the SELECTED subset, not the whole address. (EMPTY
+        // selection => the whole-address totals below, byte-identical to today.) Either
+        // way the change math stays integer-zatoshi and the no-leak guard is preserved.
+        const bool hasSelection = !tx.selectedInputs.isEmpty();
+        const qint64 eligibleZat       = hasSelection
+            ? selectedSpendableZat(tx, /*includeCoinbase=*/false)
+            : confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/false);
+        const qint64 confirmedTotalZat = hasSelection
+            ? selectedSpendableZat(tx, /*includeCoinbase=*/true)
+            : confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/true);
 
         qint64 sendZat = 0;
         for (const ToFields& t : tx.toAddrs)        // recipients only -- change not added yet
@@ -831,6 +946,54 @@ qint64 MainWindow::confirmedSpendableZat(const QString& addr, bool includeCoinba
     return sum;
 }
 
+// COIN CONTROL — selection-aware spendable total (see mainwindow.h). Matches each pinned
+// SelectedInput against the LIVE UTXO set by the exact coordinates the daemon will pin
+// (txid + per-pool index/jsindex), and sums ONLY those still confirmed + spendable. This
+// is the load-bearing money-safety primitive for a coin-control send: it re-verifies each
+// selected input is still live before the irrevocable send, and (because a since-spent/
+// unconfirmed input simply doesn't match) it can only UNDER-count, never assert phantom
+// funds. allStillSpendable is set false if ANY selected input no longer matches a live
+// confirmed-spendable row, so the caller fails closed. Returns 0 if UTXOs aren't loaded.
+qint64 MainWindow::selectedSpendableZat(const Tx& tx, bool includeCoinbase, bool* allStillSpendable) {
+    if (allStillSpendable) *allStillSpendable = false;
+    if (!rpc || !rpc->getUTXOs())
+        return 0;
+
+    // Per-pool coordinate match against a live UnspentOutput row. Mirrors the keys the
+    // typed-inputs builder (fillTxJsonParams) emits, so "still spendable" here means
+    // "the exact input we will pin is present + confirmed + spendable".
+    auto fnMatch = [](const SelectedInput& s, const UnspentOutput& u) -> bool {
+        if (s.txid != u.txid) return false;
+        if (s.type == "transparent") return u.vout == s.index;
+        if (s.type == "sapling")     return u.outindex == s.index;
+        /* sprout */                 return u.jsindex == s.jsindex && u.jsoutindex == s.index;
+    };
+
+    qint64 sum = 0;
+    bool   all = true;
+    for (const SelectedInput& s : tx.selectedInputs) {
+        bool found = false;
+        for (const UnspentOutput& u : *rpc->getUTXOs()) {
+            if (!fnMatch(s, u))
+                continue;
+            // A live match exists; require it still confirmed + spendable (+ coinbase
+            // policy) to count it. A coinbase input excluded by includeCoinbase=false is
+            // simply not summed, but it is NOT a "no longer spendable" failure.
+            if (u.confirmations > 0 && u.spendable) {
+                if (includeCoinbase || !u.coinbase)
+                    sum += toZat(u.amount.toDouble());
+                found = true;
+            }
+            break;   // matched this selected input (live or not); stop scanning
+        }
+        if (!found)
+            all = false;   // a selected input vanished / unconfirmed / unspendable
+    }
+
+    if (allStillSpendable) *allStillSpendable = all;
+    return sum;
+}
+
 // FAIL-OPEN spendable accessor. The daemon (z_sendmany, minconf=1) spends only
 // CONFIRMED, spendable inputs, so the amount the GUI offers / validates for the Available
 // line + send-max must be the confirmed-spendable figure -- NOT the minconf=0
@@ -898,25 +1061,64 @@ MainWindow::RepollResult MainWindow::repollFromAddrUtxos() {
 // seconds (poll staleness + dwell) to one RPC round-trip; fully closing it needs daemon-side
 // input pinning (z_sendmany with a fixed input set), which is a separate, daemon-side change.
 bool MainWindow::verifyAutoShieldUnchanged(const Tx& tx) {
-    if (!tx.autoShieldGuardActive)
-        return true;                                   // no-op for non-auto-shield sends
+    const bool hasSelection = !tx.selectedInputs.isEmpty();
 
-    const RepollResult r = repollFromAddrUtxos();
-    if (r != RepollResult::Refreshed) {                // could not verify -> FAIL CLOSED
-        QMessageBox::warning(this, tr("Could not verify balance"),
-            tr("Your balance could not be re-checked before sending, so for your privacy "
-               "the transaction was NOT sent. Please try again in a moment."),
-            QMessageBox::Ok);
-        return false;
+    // COIN CONTROL — when the user pinned inputs we MUST re-verify, before the irrevocable
+    // send, that every pinned input is STILL confirmed + spendable (a re-org or a parallel
+    // spend could have removed one during the confirm dwell; sending a now-invalid pinned
+    // set would make the daemon reject the whole tx). This runs for ANY selection-aware
+    // send, including a z-from send that does NOT arm the auto-shield change guard.
+    if (hasSelection) {
+        const RepollResult rs = repollFromAddrUtxos();
+        if (rs != RepollResult::Refreshed) {           // could not verify -> FAIL CLOSED
+            QMessageBox::warning(this, tr("Could not verify your selected inputs"),
+                tr("The inputs you chose could not be re-checked before sending, so the "
+                   "transaction was NOT sent. Please try again in a moment."),
+                QMessageBox::Ok);
+            return false;
+        }
+        bool allStillSpendable = false;
+        selectedSpendableZat(tx, /*includeCoinbase=*/true, &allStillSpendable);
+        if (!allStillSpendable) {
+            QMessageBox::warning(this, tr("Selected inputs changed — not sent"),
+                tr("One or more of the inputs you chose in Coin Control is no longer "
+                   "available to spend (it may have been spent or is reconfirming). The "
+                   "transaction was NOT sent. Please reopen Coin Control and choose again."),
+                QMessageBox::Ok);
+            return false;
+        }
+        // Fall through: if this is ALSO an auto-shield send the change-leak checks below
+        // run, sized against the selected subset (selectedSpendableZat). If it is not an
+        // auto-shield send, the guard is inactive and we return true after this re-verify.
+    }
+
+    if (!tx.autoShieldGuardActive)
+        return true;                                   // selection re-verified (or no-op)
+
+    // For a NON-selection auto-shield send we still need the fresh transparent re-poll the
+    // original guard relies on. (A selection-aware send already re-polled above.)
+    if (!hasSelection) {
+        const RepollResult r = repollFromAddrUtxos();
+        if (r != RepollResult::Refreshed) {            // could not verify -> FAIL CLOSED
+            QMessageBox::warning(this, tr("Could not verify balance"),
+                tr("Your balance could not be re-checked before sending, so for your privacy "
+                   "the transaction was NOT sent. Please try again in a moment."),
+                QMessageBox::Ok);
+            return false;
+        }
     }
 
     // Full-consume (no change) send: safe only while the live confirmed TOTAL still equals
     // exactly what we sized the spend against. Any new confirmation grows the total beyond
     // the frozen amount -> the daemon can fund the amount and leave the surplus as PUBLIC
     // change -> abort. (A coinbase-inclusive total is the right basis: the daemon draws the
-    // whole balance to the single z-recipient.)
+    // whole balance to the single z-recipient.) With a pinned input set the "total" is the
+    // selected subset (the daemon spends only those), not the whole address.
     if (tx.autoShieldFullConsume) {
-        if (confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/true) == tx.builtTargetZat)
+        const qint64 liveTotal = hasSelection
+            ? selectedSpendableZat(tx, /*includeCoinbase=*/true)
+            : confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/true);
+        if (liveTotal == tx.builtTargetZat)
             return true;                               // still an exact full consume -> SAFE
         QMessageBox::warning(this, tr("Balance changed — not sent"),
             tr("Your balance for this address changed while you were confirming. For your "
@@ -925,7 +1127,9 @@ bool MainWindow::verifyAutoShieldUnchanged(const Tx& tx) {
         return false;
     }
 
-    const qint64 liveEligibleZat = confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/false);
+    const qint64 liveEligibleZat = hasSelection
+        ? selectedSpendableZat(tx, /*includeCoinbase=*/false)
+        : confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/false);
     if (liveEligibleZat == tx.builtEligibleZat)
         return true;                                   // verified identical -> SAFE to send
 
@@ -933,7 +1137,9 @@ bool MainWindow::verifyAutoShieldUnchanged(const Tx& tx) {
     // emit the surplus as PUBLIC change; a SHRUNK set would make it reject. Either way the
     // stale change must NOT be sent. When the shortfall is purely mined (coinbase) funds,
     // steer the user to the dedicated shield; otherwise show the generic notice.
-    const qint64 liveTotalZat = confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/true);
+    const qint64 liveTotalZat = hasSelection
+        ? selectedSpendableZat(tx, /*includeCoinbase=*/true)
+        : confirmedSpendableZat(tx.fromAddr, /*includeCoinbase=*/true);
     if (tx.builtTargetZat <= liveTotalZat && tx.builtTargetZat > liveEligibleZat) {
         QMessageBox::warning(this, tr("Shield your mined funds first"),
             tr("Part of this address's balance is newly mined (coinbase) coins, which can "

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -272,6 +272,27 @@ void Settings::setAllowCustomFees(bool allow) {
     QSettings().setValue("options/customfees", allow);
 }
 
+bool Settings::getCoinControlEnabled() {
+    // COIN CONTROL is an Advanced, opt-in feature. Default OFF so the Send tab is
+    // unchanged for everyone who doesn't deliberately turn it on.
+    return QSettings().value("options/coincontrol", false).toBool();
+}
+
+void Settings::setCoinControlEnabled(bool on) {
+    QSettings().setValue("options/coincontrol", on);
+}
+
+bool Settings::getManualShieldedSelection() {
+    // Manual shielded-note selection is OFF by default: auto-selection is privacy-
+    // optimized, and hand-picking notes can reduce privacy. Surfaced only inside the
+    // Coin Control dialog, and only when Coin Control itself is enabled.
+    return QSettings().value("options/coincontrolshielded", false).toBool();
+}
+
+void Settings::setManualShieldedSelection(bool on) {
+    QSettings().setValue("options/coincontrolshielded", on);
+}
+
 bool Settings::isWalletBackedUp() {
     // Load from the QT Settings. Defaults to false so a brand-new wallet is
     // treated as un-backed-up until the user actually confirms a backup.

--- a/src/settings.h
+++ b/src/settings.h
@@ -91,7 +91,24 @@ public:
 
     bool    getAllowCustomFees();
     void    setAllowCustomFees(bool allow);
-            
+
+    // COIN CONTROL (Advanced, default OFF). When ON, the Send tab shows a "Coin
+    // Control…" button next to the from-address combo so the user can pin exactly which
+    // already-valid inputs a payment spends. The button is additionally gated on daemon
+    // support (RPC::coinControlSupported()), so turning this on never offers a feature
+    // the connected daemon can't honor.
+    bool    getCoinControlEnabled();
+    void    setCoinControlEnabled(bool on);
+
+    // COIN CONTROL — manual shielded-note selection (Advanced, default OFF). When OFF,
+    // the Coin Control dialog shows shielded (sapling/sprout) notes for visibility but
+    // leaves them UNcheckable; auto-selection stays privacy-optimized. When ON, the user
+    // may pick individual shielded notes (a one-time privacy warning is shown on first
+    // enable). Separate from getCoinControlEnabled so transparent coin control can be
+    // used without ever exposing per-note selection.
+    bool    getManualShieldedSelection();
+    void    setManualShieldedSelection(bool on);
+
     bool    isSaplingActive();
 
     void    setUsingZClassicConf(QString confLocation);

--- a/src/settings.ui
+++ b/src/settings.ui
@@ -340,6 +340,47 @@
         </widget>
        </item>
        <item row="6" column="0">
+        <widget class="Line" name="line_5">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QCheckBox" name="chkCoinControl">
+         <property name="text">
+          <string>Enable Coin Control (choose which inputs a payment spends)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="label_coincontrol">
+         <property name="text">
+          <string>Advanced. Adds a &quot;Coin Control…&quot; button to the Send tab so you can pick exactly which already-confirmed inputs a payment spends. This only restricts which of your own valid inputs are used; it never changes fees, change, or how transactions are formed. Shown only when your node supports it. Default: off.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QCheckBox" name="chkManualShielded">
+         <property name="text">
+          <string>Allow manual shielded note selection in Coin Control</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="label_manualshielded">
+         <property name="text">
+          <string>Advanced. Lets you hand-pick individual shielded (z) notes in Coin Control. Manually selecting shielded notes can REDUCE your privacy; automatic selection is privacy-optimized. Default: off.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/zcl-qt-wallet.pro
+++ b/zcl-qt-wallet.pro
@@ -51,6 +51,7 @@ SOURCES += \
     src/3rdparty/qrcode/QrSegment.cpp \
     src/settings.cpp \
     src/sendtab.cpp \
+    src/coincontroldialog.cpp \
     src/senttxstore.cpp \
     src/txtablemodel.cpp \
     src/turnstile.cpp \
@@ -76,6 +77,7 @@ HEADERS += \
     src/3rdparty/qrcode/QrSegment.hpp \
     src/3rdparty/json/json.hpp \
     src/settings.h \
+    src/coincontroldialog.h \
     src/txtablemodel.h \
     src/senttxstore.h \
     src/turnstile.h \
@@ -95,7 +97,8 @@ FORMS += \
     src/turnstile.ui \
     src/turnstileprogress.ui \
     src/privkey.ui \
-    src/memodialog.ui \ 
+    src/memodialog.ui \
+    src/coincontroldialog.ui \
     src/connection.ui \
     src/addressbook.ui \
     src/createzclassicconfdialog.ui \


### PR DESCRIPTION
## What

Adds an **Advanced, opt-in, daemon-gated Coin Control dialog** to the Send tab so a user can pin exactly which already-valid inputs a payment spends. Off by default; the Send tab is byte-identical to today for everyone who does not deliberately enable it.

## Consensus impact: NONE

Coin Control **only restricts which already-valid inputs the wallet offers to `z_sendmany`**. It does **not** touch tx/note format, validation, PoW, fee, dust, coinbase rules, change-output routing, or turnstile logic. With no selection (the default), behavior is unchanged.

## Inputs schema / UI

- **New `src/coincontroldialog.{h,cpp,ui}`** (modeled on the inline `memoDialog` pattern in `sendtab.cpp`): a `QTableWidget` with columns **[Use (checkbox), Address, Amount, Confirmations, Type (transparent/sapling/sprout), Change?]**.
- Rows come from the wallet's existing UTXO/note set (`RPC::getUTXOs()`, populated from the daemon's own `listunspent` + `z_listunspent` via the reused `processUnspent` parser), filtered to the currently selected from-address and to **confirmed + spendable** outputs (so the dialog can never offer something the daemon would reject).
- A live running **SUM of checked inputs** is shown, with a green/red verdict on whether it covers the entered **amount + fee** (all integer zatoshi).
- `UnspentOutput` / `processUnspent` were extended to capture the per-output coordinates the daemon needs to pin an input: transparent `vout`, Sapling `outindex`, Sprout `jsindex`+`jsoutindex`, plus the `change` flag (all default-initialized so `UnspentOutput` stays a C++14 brace-init aggregate).

## Tx wiring

- `Tx` gains a **default-empty** `QList<SelectedInput> selectedInputs = {}` (the `{}` keeps `Tx` a brace-init aggregate; **empty == auto-select == today's behavior exactly**).
- `fillTxJsonParams`: when `selectedInputs` is non-empty, the typed `inputs` array is the **5th positional** `z_sendmany` arg, so **all** positional args are emitted: `[fromAddress, recipients, minconf=1, fee, inputsArray]`. `minconf=1` is `z_sendmany`'s own default and `fee` is the same (default or custom) fee the legacy path sends. The legacy empty-selection path is unchanged (fee/minconf appended only with custom fees, no inputs array).
- Inputs are typed per pool: `{txid, vout}` (transparent), `{txid, outindex}` (sapling), `{txid, jsindex, jsoutindex}` (sprout).

## Daemon-support gate (important)

The stock ZClassic `z_sendmany` accepts only 4 params (`fromaddress`, `amounts`, `minconf`, `fee`) and **rejects `params.size() > 4`** — it has **no** `inputs` argument. Per the spec's safety requirement, we **probe capability once** (`help z_sendmany`, parsed for an `inputs` argument) and, if the daemon lacks it, **hide Coin Control entirely** rather than ever silently dropping the user's selection. The probe is fail-safe (default OFF; any RPC error / parse ambiguity leaves it hidden). **On today's ZClassic daemon, Coin Control will therefore stay hidden until a daemon that advertises the `inputs` param is connected.**

## Money-safety invariants preserved

- The send guards are **selection-aware**: when `selectedInputs` is non-empty, the auto-shield change sizing (`createTxFromSendPage`) and the pre-send race gate (`verifyAutoShieldUnchanged`) size against the **selected subset total** (integer zatoshi via `toZat`), not the whole address.
- Before the irrevocable send, **each selected input is re-verified still confirmed+spendable** (re-poll + coordinate match); any vanished/unconfirmed input fails the send **closed** with a clear message.
- The **change-leak guard is intact**: the explicit Sapling change output is sized to consume the selected inputs **exactly** (residual 0), so an auto-shield send with a pinned set still cannot emit public transparent change. The coinbase band-abort logic now operates on the selected subset.
- `selectedSpendableZat()` can only **under-count** (a since-spent input simply doesn't match), never assert phantom funds.

## Privacy gating

- Shielded-note checkboxes are enabled **only** behind an Advanced \"manual shielded note selection\" setting (default OFF). When off, shielded notes are shown for visibility but are not checkable (auto-selection stays privacy-optimized).
- On first enable, a **one-time warning** explains that manually selecting shielded notes can reduce privacy and that auto-selection is privacy-optimized.

## Build / test status

- New files added to `.pro` (SOURCES/HEADERS/FORMS). `.ui` files validated; both new `.ui` and the two new Settings checkboxes generate clean C++ via `uic`.
- All modified TUs pass `g++ -std=c++14 -fsyntax-only` against Qt5 (only the codebase's pre-existing deprecation warnings remain).

**DRAFT: pending maintainer build + gtest + a live funded send-with-change.** Not yet exercised against a live daemon that advertises the `z_sendmany inputs` param (none ships today), so the typed-inputs send path and the selection-aware guards have been verified by reading + syntax-check only.

### Known limitations / notes
- For a **z-from** coin-control send the pre-send re-verify uses the last-polled shielded-note set (the synchronous re-poll only refreshes transparent UTXOs); this can only over-abort, never leak — a full close needs daemon-side input pinning.
- The recurring-send path is currently hidden in the UI; a pinned selection is not intended to persist into a stored schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)