### PR TITLE
Encrypt Sensitive transaction data at rest using SecureStore with master-password

### DIFF
--- a/docs/OPSEC_ENCRYPTION.md
+++ b/docs/OPSEC_ENCRYPTION.md
@@ -1,0 +1,112 @@
+# OPSEC: Encryption of wallet data at rest
+
+> **Status: implemented** (`src/securestore.{h,cpp}` + store refactors). Branch `opsec-encryption`.
+
+## 1. Threat model
+
+A local adversary who can **read the user's disk or a backup of it** (stolen/seized laptop, leaked
+cloud backup, forensic image, a shared/again-sold machine) must learn **nothing** about the user's
+shielded activity from the files this GUI writes. The daemon's `wallet.dat` (spend keys) is out of
+scope here — that's protected by the node's own `encryptwallet` (the future "multi-cipher wallet
+encryption"). This document covers everything the **GUI** writes.
+
+## 2. Audit — what the GUI wrote, and the fix
+
+All live in the app-data dir (Linux `~/.local/share/zcl-qt-wallet-org/…`).
+
+| File | Was | Sensitivity | Now |
+|---|---|---|---|
+| `senttxstore.dat` | JSON plaintext: shielded send history (from/to z-addrs, amounts, fees, txids, times) | 🔴 critical — the daemon can't even see z→z sends; this was the only record | **`senttxstore.enc`**, encrypted |
+| `addresslabels.dat` | QDataStream plaintext: address ↔ human label | 🔴 critical — deanonymizes addresses | **`addresslabels.enc`**, encrypted |
+| `turnstilemigrationplan.dat` | QDataStream plaintext: z→t→z migration plan | 🟠 high — reveals linkage | **`turnstilemigrationplan.enc`**, encrypted |
+| `zcl-qt-wallet.log` | plaintext diagnostics | 🟡 medium — persistent | **OFF by default** (opt-in `options/savedebuglog`) |
+| QSettings `connection/rpcpassword` | plaintext INI | 🟡 medium — daemon RPC creds | **residual, documented below** |
+
+**Residual (honest):** the daemon's RPC password also lives in `zclassic.conf` in plaintext because
+**the daemon itself must read it** — we cannot encrypt that without breaking the node. Encrypting only
+the GUI's QSettings copy would be theatre while the same secret sits in `zclassic.conf`. Mitigation:
+the RPC password gates *node access*, not spend keys, and our app-data dir/files are written `0700`/
+`0600` (owner-only). A future option is to stop the GUI duplicating it into QSettings and read it from
+`zclassic.conf` on demand. User-initiated **CSV export** and **wallet.dat backup** write to a path the
+user chooses — deliberate exports, not silent leaks.
+
+## 3. SecureStore — the encryption core
+
+One master secret, derived once at startup, protects every file via a single container format.
+
+### KDF (the real front line)
+- **Argon2id** (`crypto_pwhash`), **SENSITIVE** params (~1 GiB RAM, multi-second) → 256-bit master
+  key. Memory-hard ⇒ brute-force is dominated by RAM cost, not cipher speed.
+- **Strict: SENSITIVE only — no weaker tier.** There is intentionally no MODERATE option and no
+  silent downgrade: we never weaken the brute-force cost behind the user's back. If a machine truly
+  cannot allocate the ~1 GiB, setup **fails loudly** rather than producing a weaker key.
+- The exact parameters are recorded in the verifier, so unlock always reproduces the key.
+- Salt is random per wallet, stored in the verifier file.
+- Because derivation takes a few seconds, both setup and unlock run it on a **worker thread behind a
+  splash** (ZCL logo + "Decrypting…/Encrypting…" + animated progress) so the UI never freezes blankly.
+
+### Cipher — a two-layer AEAD cascade (defense-in-depth)
+Independent subkeys are derived from the master key with `crypto_kdf` (BLAKE2b), context `zclstore`:
+
+```
+plaintext
+  → inner: XChaCha20-Poly1305  (stream family, 192-bit random nonce, misuse-resistant)
+  → outer: AES-256-GCM         (block family — cipher-family diversity)
+  = blob
+```
+
+A cryptanalytic break of **either** cipher still leaves the data sealed by the other. Where AES-NI is
+unavailable (e.g. some ARM), the outer layer falls back to a **second, independent-key**
+XChaCha20-Poly1305; the choice is recorded in the blob's `mode` byte so files stay self-describing.
+
+**Quantum:** for password-based *symmetric* encryption, Grover only halves brute-force strength, so
+256-bit keys give ~128-bit post-quantum security — ample. (Shor threatens *public-key* crypto, which
+we don't use here.) The cascade is about *classical* future-proofing, not quantum.
+
+### Blob format
+```
+'Z''C''S' | ver(1) | mode(1) | inner_nonce(24) | outer_nonce(12|24) | ciphertext
+  mode 0 = XChaCha20-Poly1305 then AES-256-GCM
+  mode 1 = XChaCha20-Poly1305 then XChaCha20-Poly1305 (independent key)
+```
+
+### Verifier (`master.bin`)
+```
+"ZCK1" | ver(1) | secretType(1) | salt(16) | argon2_ops(8) | argon2_mem(8) | enc(canary)
+```
+Unlock = derive key from the supplied secret + stored salt/params, then AEAD-decrypt the canary; the
+Poly1305/GCM tag *is* the password check (no plaintext comparison of secrets).
+
+### Key hygiene
+Master key is held in `sodium_mlock`'d memory for the session and `sodium_memzero`'d on lock/exit.
+Subkeys and secret buffers are zeroed immediately after use. Files are written atomically
+(`QSaveFile`) with `0600` perms; the data dir is `0700`.
+
+## 4. Unlock factors (password / keyfile / both)
+
+At first run the user picks:
+- **Password** — something memorised.
+- **Keyfile** — any file the user keeps elsewhere (USB stick…); its full contents are BLAKE2b-hashed
+  and stretched by Argon2id like a password. Nothing to memorise, but **lose it = lose access**.
+- **Both** — bound together as `Argon2id( BLAKE2b(password ‖ keyfileHash) )`; a stolen disk needs the
+  keyfile *and* the password.
+
+The chosen type is recorded in the verifier so later unlocks prompt for the right factor(s).
+
+## 5. First-run, unlock, and reset behavior
+
+- **First run** shows a notice (history, labels and the turnstile plan will be encrypted; the same
+  secret will later unlock wallet key encryption; **there is no recovery**), then the factor chooser
+  + setup.
+- **Returning runs** prompt to unlock *before any window or store touches disk*. Cancelling/Quitting
+  **refuses to start** — the app never falls back to writing plaintext.
+- **Wrong secret** → Try again / **Reset** / Quit. Reset (double-confirmed) purges all managed
+  encrypted files + the verifier and drops into fresh setup. **Coins are unaffected** — they live in
+  `wallet.dat`, which this never touches.
+- **Legacy migration:** on first unlock, any existing plaintext `*.dat` is read, re-written as `*.enc`,
+  and the cleartext original is deleted — transparent in-place upgrade.
+
+## 6. Known follow-ups
+- A Settings checkbox to toggle the (default-off) plaintext debug log.
+- Optionally stop duplicating the RPC password into QSettings (read from `zclassic.conf`).
+- Re-lock / re-prompt on a configurable idle timeout.

--- a/src/addressbook.cpp
+++ b/src/addressbook.cpp
@@ -2,6 +2,7 @@
 #include "ui_addressbook.h"
 #include "ui_mainwindow.h"
 #include "settings.h"
+#include "securestore.h"
 #include "mainwindow.h"
 #include "rpc.h"
 
@@ -242,41 +243,41 @@ AddressBook::AddressBook() {
 }
 
 void AddressBook::readFromStorage() {
-    QFile file(AddressBook::writeableFile());
-
-    if (!file.exists()) {
+    // Address labels link real-world identities to addresses — encrypted at rest. Transparently
+    // migrate a legacy plaintext addresslabels.dat to the encrypted .enc on first read.
+    QByteArray bytes = SecureStore::getInstance()->migrateIfNeeded(legacyFile(), writeableFile());
+    if (bytes.isEmpty())
         return;
-    }
 
     allLabels.clear();
-    file.open(QIODevice::ReadOnly);
-    QDataStream in(&file);    // read the data serialized from the file
+    QDataStream in(&bytes, QIODevice::ReadOnly);
     QString version;
-    in >> version >> allLabels; 
-
-    file.close();
+    in >> version >> allLabels;
 }
 
 void AddressBook::writeToStorage() {
-    QFile file(AddressBook::writeableFile());
-    file.open(QIODevice::ReadWrite | QIODevice::Truncate);
-    QDataStream out(&file);   // we will serialize the data into the file
-    out << QString("v1") << allLabels;
-    file.close();
+    QByteArray bytes;
+    {
+        QDataStream out(&bytes, QIODevice::WriteOnly);
+        out << QString("v1") << allLabels;
+    }
+    SecureStore::getInstance()->writeFile(writeableFile(), bytes);
 }
 
-QString AddressBook::writeableFile() {
-    auto filename = QStringLiteral("addresslabels.dat");
-
+static QString addrBookPath(const QString& filename) {
     auto dir = QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
     if (!dir.exists())
         QDir().mkpath(dir.absolutePath());
+    return Settings::getInstance()->isTestnet() ? dir.filePath("testnet-" % filename)
+                                                : dir.filePath(filename);
+}
 
-    if (Settings::getInstance()->isTestnet()) {
-        return dir.filePath("testnet-" % filename);
-    } else {
-        return dir.filePath(filename);
-    }
+QString AddressBook::writeableFile() {
+    return addrBookPath(QStringLiteral("addresslabels.enc"));
+}
+
+QString AddressBook::legacyFile() {
+    return addrBookPath(QStringLiteral("addresslabels.dat"));
 }
 
 

--- a/src/addressbook.h
+++ b/src/addressbook.h
@@ -59,6 +59,7 @@ private:
     void writeToStorage();
 
     QString writeableFile();
+    QString legacyFile();
     QList<QPair<QString, QString>> allLabels;
 
     static AddressBook* instance;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "mainwindow.h"
 #include "rpc.h"
 #include "settings.h"
+#include "securestore.h"
 #include "turnstile.h"
 #include "notifyserver.h"   // NOTIFY-SRV connector mode (--notify)
 #include "guistartup.h"     // [gui-startup] client-side startup timing milestones
@@ -327,6 +328,14 @@ public:
                 QObject::tr("A required security library (libsodium) failed to "
                             "initialize. Please reinstall ZclWallet."));
             return 1;
+        }
+
+        // OPSEC: unlock (or first-run set up) the master-password-encrypted data store BEFORE any
+        // window or store reads/writes a file, so transaction history, address labels and the
+        // turnstile plan are never written in the clear. If the user declines (cancel/quit),
+        // refuse to start rather than fall back to plaintext.
+        if (!SecureStore::getInstance()->bootstrap(nullptr)) {
+            return 0;
         }
 
         // Check for embedded option

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -44,7 +44,12 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
-    logger = new Logger(this, QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)).filePath("zcl-qt-wallet.log"));
+    // OPSEC: the debug log is plaintext on disk, so it's OFF by default. Power users can opt in
+    // (Settings) when they need diagnostics; an empty filename makes Logger a no-op sink.
+    QString logFile = Settings::getInstance()->getSaveDebugLog()
+        ? QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)).filePath("zcl-qt-wallet.log")
+        : QString();
+    logger = new Logger(this, logFile);
 
     // SELF-HEAL: a heal/inProgress flag seen at PROCESS STARTUP is necessarily stale —
     // it's a persisted QSettings flag that a prior session set just before a deferred

--- a/src/securestore.cpp
+++ b/src/securestore.cpp
@@ -1,0 +1,583 @@
+#include "securestore.h"
+#include "settings.h"
+
+#include <QStandardPaths>
+#include <QDir>
+#include <QFile>
+#include <QSaveFile>
+#include <QMessageBox>
+#include <QInputDialog>
+#include <QLineEdit>
+#include <QFileDialog>
+#include <QWidget>
+#include <QVBoxLayout>
+#include <QLabel>
+#include <QProgressBar>
+#include <QMovie>
+#include <QApplication>
+#include <QScreen>
+#include <QEventLoop>
+#include <QThread>
+#include <functional>
+#include <thread>
+#include <atomic>
+
+// The 8-byte (crypto_kdf_CONTEXTBYTES) domain-separation context for subkey derivation.
+static const char* KDF_CTX = "zclstore";
+static const QByteArray kCanary = QByteArrayLiteral("zcl-secure-store-canary-v1");
+static const QByteArray kBlobMagic = QByteArrayLiteral("ZCS");
+static const QByteArray kVerMagic  = QByteArrayLiteral("ZCK1");
+
+// Atomic, owner-only (0600) write.
+static bool atomicWrite(const QString& path, const QByteArray& bytes) {
+    QSaveFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) return false;
+    if (f.write(bytes) != bytes.size()) { f.cancelWriting(); return false; }
+    if (!f.commit()) return false;
+    QFile::setPermissions(path, QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+    return true;
+}
+
+SecureStore::SecureStore() {
+    sodium_memzero(masterKey, sizeof masterKey);
+}
+
+SecureStore::~SecureStore() {
+    lock();
+}
+
+SecureStore* SecureStore::getInstance() {
+    static SecureStore inst;
+    return &inst;
+}
+
+QString SecureStore::dataDir() {
+    QString dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    QDir().mkpath(dir);
+    // Owner-only directory (0700) so siblings can't enumerate our encrypted files.
+    QFile::setPermissions(dir, QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner);
+    return dir;
+}
+
+QString SecureStore::verifierPath() const {
+    return QDir(dataDir()).filePath("master.bin");
+}
+
+bool SecureStore::verifierExists() const {
+    return QFile::exists(verifierPath());
+}
+
+void SecureStore::lock() {
+    sodium_memzero(masterKey, sizeof masterKey);
+    if (keyLocked) { sodium_munlock(masterKey, sizeof masterKey); keyLocked = false; }
+    unlocked = false;
+}
+
+// Hash a keyfile's full contents to a fixed 32-byte value (BLAKE2b). Empty if unreadable.
+static QByteArray hashKeyfile(const QString& path) {
+    QFile f(path);
+    if (path.isEmpty() || !f.open(QIODevice::ReadOnly)) return QByteArray();
+    crypto_generichash_state st;
+    crypto_generichash_init(&st, nullptr, 0, crypto_generichash_BYTES);
+    char buf[65536];
+    qint64 n;
+    while ((n = f.read(buf, sizeof buf)) > 0)
+        crypto_generichash_update(&st, (const unsigned char*) buf, (unsigned long long) n);
+    f.close();
+    QByteArray out(crypto_generichash_BYTES, 0);
+    crypto_generichash_final(&st, (unsigned char*) out.data(), out.size());
+    return out;
+}
+
+QByteArray SecureStore::buildSecret(SecretType type, const QString& password,
+                                    const QString& keyfilePath) const {
+    QByteArray pw = password.toUtf8();
+    QByteArray kf = (type == SecretPassword) ? QByteArray() : hashKeyfile(keyfilePath);
+
+    if (type == SecretKeyfile)  return kf;                 // keyfile-only
+    if (type == SecretPassword) return pw;                 // password-only
+    // Both: bind them together so neither alone suffices — BLAKE2b(password || keyfileHash).
+    if (kf.isEmpty()) return QByteArray();
+    crypto_generichash_state st;
+    crypto_generichash_init(&st, nullptr, 0, crypto_generichash_BYTES);
+    crypto_generichash_update(&st, (const unsigned char*) pw.constData(), pw.size());
+    crypto_generichash_update(&st, (const unsigned char*) kf.constData(), kf.size());
+    QByteArray out(crypto_generichash_BYTES, 0);
+    crypto_generichash_final(&st, (unsigned char*) out.data(), out.size());
+    sodium_memzero(pw.data(), pw.size());
+    return out;
+}
+
+bool SecureStore::deriveMaster(const QByteArray& secret, const unsigned char* salt,
+                               quint64 ops, quint64 mem) {
+    if (secret.isEmpty()) return false;
+    if (!keyLocked) { sodium_mlock(masterKey, sizeof masterKey); keyLocked = true; }
+    int rc = crypto_pwhash(masterKey, sizeof masterKey, secret.constData(), secret.size(), salt,
+                           ops, (size_t) mem, crypto_pwhash_ALG_ARGON2ID13);
+    return rc == 0;
+}
+
+// ---------------------------------------------------------------------------
+// Two-layer AEAD cascade with independent subkeys (see securestore.h).
+// Blob: 'Z''C''S' | ver(1) | mode(1) | inner_nonce(24) | outer_nonce(12|24) | ciphertext
+//   mode 0 = XChaCha20-Poly1305 (inner) then AES-256-GCM (outer)
+//   mode 1 = XChaCha20-Poly1305 (inner) then XChaCha20-Poly1305 (outer, independent key)
+// ---------------------------------------------------------------------------
+QByteArray SecureStore::encrypt(const QByteArray& plain) {
+    if (!unlocked) return QByteArray();
+
+    unsigned char kin[32], kout[32];
+    crypto_kdf_derive_from_key(kin,  sizeof kin,  1, KDF_CTX, masterKey);
+    crypto_kdf_derive_from_key(kout, sizeof kout, 2, KDF_CTX, masterKey);
+
+    // Inner layer — XChaCha20-Poly1305 (192-bit random nonce, misuse-resistant).
+    const int NIN = crypto_aead_xchacha20poly1305_ietf_NPUBBYTES;
+    unsigned char nin[crypto_aead_xchacha20poly1305_ietf_NPUBBYTES];
+    randombytes_buf(nin, sizeof nin);
+    QByteArray c1(plain.size() + crypto_aead_xchacha20poly1305_ietf_ABYTES, 0);
+    unsigned long long c1len = 0;
+    crypto_aead_xchacha20poly1305_ietf_encrypt(
+        (unsigned char*) c1.data(), &c1len,
+        (const unsigned char*) plain.constData(), plain.size(),
+        nullptr, 0, nullptr, nin, kin);
+    c1.resize((int) c1len);
+
+    // Outer layer — AES-256-GCM where AES-NI exists, else a second independent XChaCha20.
+    bool aes = crypto_aead_aes256gcm_is_available() != 0;
+    char mode = aes ? 0 : 1;
+    QByteArray nout, c2;
+    unsigned long long c2len = 0;
+    if (aes) {
+        nout.resize(crypto_aead_aes256gcm_NPUBBYTES);
+        randombytes_buf((unsigned char*) nout.data(), nout.size());
+        c2.resize(c1.size() + crypto_aead_aes256gcm_ABYTES);
+        crypto_aead_aes256gcm_encrypt(
+            (unsigned char*) c2.data(), &c2len,
+            (const unsigned char*) c1.constData(), c1.size(),
+            nullptr, 0, nullptr, (const unsigned char*) nout.constData(), kout);
+    } else {
+        nout.resize(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+        randombytes_buf((unsigned char*) nout.data(), nout.size());
+        c2.resize(c1.size() + crypto_aead_xchacha20poly1305_ietf_ABYTES);
+        crypto_aead_xchacha20poly1305_ietf_encrypt(
+            (unsigned char*) c2.data(), &c2len,
+            (const unsigned char*) c1.constData(), c1.size(),
+            nullptr, 0, nullptr, (const unsigned char*) nout.constData(), kout);
+    }
+    c2.resize((int) c2len);
+    sodium_memzero(kin, sizeof kin);
+    sodium_memzero(kout, sizeof kout);
+
+    QByteArray out;
+    out.append(kBlobMagic);          // 'Z''C''S'
+    out.append((char) 1);            // version
+    out.append(mode);
+    out.append((const char*) nin, NIN);
+    out.append(nout);
+    out.append(c2);
+    return out;
+}
+
+bool SecureStore::decrypt(const QByteArray& blob, QByteArray& plainOut) {
+    if (!unlocked) return false;
+    const int HDR = 5;   // magic(3) + ver(1) + mode(1)
+    const int NIN = crypto_aead_xchacha20poly1305_ietf_NPUBBYTES;
+    if (blob.size() < HDR + NIN) return false;
+    if (blob.left(3) != kBlobMagic) return false;
+    char mode = blob.at(4);
+    int noutLen = (mode == 0) ? crypto_aead_aes256gcm_NPUBBYTES
+                              : crypto_aead_xchacha20poly1305_ietf_NPUBBYTES;
+    if (blob.size() <= HDR + NIN + noutLen) return false;
+
+    const unsigned char* p    = (const unsigned char*) blob.constData();
+    const unsigned char* nin  = p + HDR;
+    const unsigned char* nout = nin + NIN;
+    const unsigned char* c2   = nout + noutLen;
+    int c2len = blob.size() - (HDR + NIN + noutLen);
+
+    unsigned char kin[32], kout[32];
+    crypto_kdf_derive_from_key(kin,  sizeof kin,  1, KDF_CTX, masterKey);
+    crypto_kdf_derive_from_key(kout, sizeof kout, 2, KDF_CTX, masterKey);
+
+    // Outer decrypt -> c1
+    QByteArray c1(c2len, 0);
+    unsigned long long c1len = 0;
+    int rc;
+    if (mode == 0) {
+        if (crypto_aead_aes256gcm_is_available() == 0) {
+            sodium_memzero(kin, sizeof kin); sodium_memzero(kout, sizeof kout);
+            return false;   // file needs AES-NI to read; this machine lacks it
+        }
+        rc = crypto_aead_aes256gcm_decrypt((unsigned char*) c1.data(), &c1len, nullptr,
+                 c2, c2len, nullptr, 0, nout, kout);
+    } else {
+        rc = crypto_aead_xchacha20poly1305_ietf_decrypt((unsigned char*) c1.data(), &c1len, nullptr,
+                 c2, c2len, nullptr, 0, nout, kout);
+    }
+    if (rc != 0) { sodium_memzero(kin, sizeof kin); sodium_memzero(kout, sizeof kout); return false; }
+    c1.resize((int) c1len);
+
+    // Inner decrypt -> plaintext
+    QByteArray plain(c1.size(), 0);
+    unsigned long long plen = 0;
+    rc = crypto_aead_xchacha20poly1305_ietf_decrypt((unsigned char*) plain.data(), &plen, nullptr,
+             (const unsigned char*) c1.constData(), c1.size(), nullptr, 0, nin, kin);
+    sodium_memzero(kin, sizeof kin);
+    sodium_memzero(kout, sizeof kout);
+    if (rc != 0) return false;
+    plain.resize((int) plen);
+    plainOut = plain;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Master password / verifier
+// ---------------------------------------------------------------------------
+// Verifier: "ZCK1" | ver(1) | secretType(1) | salt(16) | ops(8) | mem(8) | canaryBlob
+static const int kVerHead = 4 + 1 + 1 + crypto_pwhash_SALTBYTES + 8 + 8;
+
+SecureStore::SecretType SecureStore::storedSecretType() const {
+    QFile f(verifierPath());
+    if (!f.open(QIODevice::ReadOnly)) return SecretPassword;
+    QByteArray v = f.read(6);
+    f.close();
+    if (v.size() < 6 || v.left(4) != kVerMagic) return SecretPassword;
+    int t = (unsigned char) v.at(5);
+    return (t == SecretKeyfile || t == SecretBoth) ? (SecretType) t : SecretPassword;
+}
+
+bool SecureStore::createMaster(SecretType type, const QString& password, const QString& keyfilePath) {
+    if (verifierExists()) return false;
+    QByteArray secret = buildSecret(type, password, keyfilePath);
+    if (secret.isEmpty()) return false;
+
+    unsigned char salt[crypto_pwhash_SALTBYTES];
+    randombytes_buf(salt, sizeof salt);
+
+    // Strict: ALWAYS Argon2id SENSITIVE (~1 GiB, multi-second). No weaker fallback — we never
+    // silently downgrade the brute-force cost. The exact parameters are recorded in the verifier
+    // so unlock reproduces the key. If this machine can't allocate SENSITIVE, setup fails loudly.
+    quint64 ops = crypto_pwhash_OPSLIMIT_SENSITIVE;
+    quint64 mem = crypto_pwhash_MEMLIMIT_SENSITIVE;
+    if (!deriveMaster(secret, salt, ops, mem)) {
+        sodium_memzero(secret.data(), secret.size());
+        lock();
+        return false;
+    }
+    sodium_memzero(secret.data(), secret.size());
+    unlocked = true;
+
+    QByteArray cblob = encrypt(kCanary);
+    if (cblob.isEmpty()) { lock(); return false; }
+
+    QByteArray v;
+    v.append(kVerMagic);               // "ZCK1"
+    v.append((char) 1);                // version
+    v.append((char) type);             // secret type
+    v.append((const char*) salt, (int) sizeof salt);
+    for (int i = 0; i < 8; i++) v.append((char) ((ops >> (8 * i)) & 0xff));
+    for (int i = 0; i < 8; i++) v.append((char) ((mem >> (8 * i)) & 0xff));
+    v.append(cblob);
+    if (!atomicWrite(verifierPath(), v)) { lock(); return false; }
+    return true;
+}
+
+bool SecureStore::unlock(SecretType type, const QString& password, const QString& keyfilePath) {
+    QFile f(verifierPath());
+    if (!f.open(QIODevice::ReadOnly)) return false;
+    QByteArray v = f.readAll();
+    f.close();
+
+    if (v.size() < kVerHead) return false;
+    if (v.left(4) != kVerMagic) return false;
+
+    const unsigned char* salt = (const unsigned char*) v.constData() + 6;
+    const unsigned char* q    = salt + crypto_pwhash_SALTBYTES;
+    quint64 ops = 0, mem = 0;
+    for (int i = 0; i < 8; i++) ops |= ((quint64) (unsigned char) q[i])     << (8 * i);
+    for (int i = 0; i < 8; i++) mem |= ((quint64) (unsigned char) q[8 + i]) << (8 * i);
+    QByteArray cblob = v.mid(kVerHead);
+
+    QByteArray secret = buildSecret(type, password, keyfilePath);
+    if (!deriveMaster(secret, salt, ops, mem)) { sodium_memzero(secret.data(), secret.size()); lock(); return false; }
+    sodium_memzero(secret.data(), secret.size());
+    unlocked = true;
+
+    QByteArray got;
+    if (!decrypt(cblob, got) || got != kCanary) { lock(); return false; }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// File helpers + migration
+// ---------------------------------------------------------------------------
+bool SecureStore::writeFile(const QString& path, const QByteArray& plain) {
+    if (!unlocked) return false;
+    QByteArray blob = encrypt(plain);
+    if (blob.isEmpty() && !plain.isEmpty()) return false;
+    return atomicWrite(path, blob);
+}
+
+bool SecureStore::readFile(const QString& path, QByteArray& plainOut) {
+    if (!unlocked) return false;
+    QFile f(path);
+    if (!f.exists() || !f.open(QIODevice::ReadOnly)) return false;
+    QByteArray blob = f.readAll();
+    f.close();
+    return decrypt(blob, plainOut);
+}
+
+QByteArray SecureStore::migrateIfNeeded(const QString& legacyPath, const QString& encPath) {
+    QByteArray plain;
+    if (QFile::exists(encPath)) {
+        readFile(encPath, plain);
+        return plain;
+    }
+    QFile lf(legacyPath);
+    if (lf.exists() && lf.open(QIODevice::ReadOnly)) {
+        plain = lf.readAll();
+        lf.close();
+        if (writeFile(encPath, plain))
+            lf.remove();   // upgraded in place — drop the cleartext original
+    }
+    return plain;
+}
+
+// ---------------------------------------------------------------------------
+// Reset (used when the user forgot the password and chooses to start fresh)
+// ---------------------------------------------------------------------------
+void SecureStore::purgeAllData() {
+    QDir d(dataDir());
+    static const char* bases[] = {
+        "senttxstore", "addresslabels", "turnstilemigrationplan"
+    };
+    for (const char* b : bases) {
+        for (const QString& pfx : { QStringLiteral(""), QStringLiteral("testnet-") }) {
+            d.remove(pfx % QString(b) % ".enc");
+            d.remove(pfx % QString(b) % ".dat");
+        }
+    }
+    d.remove("master.bin");
+    lock();
+}
+
+// ---------------------------------------------------------------------------
+// Interactive bootstrap at startup
+// ---------------------------------------------------------------------------
+// Prompt for the secret(s) of a given type. For create==true a password is asked twice and
+// confirmed. Returns false if the user cancelled. On success, `password`/`keyfile` are filled.
+static bool promptSecret(QWidget* parent, SecureStore::SecretType type, bool create,
+                         QString& password, QString& keyfile) {
+    password.clear(); keyfile.clear();
+
+    if (type == SecureStore::SecretKeyfile || type == SecureStore::SecretBoth) {
+        keyfile = QFileDialog::getOpenFileName(parent,
+            QObject::tr("Choose your keyfile"), QString());
+        if (keyfile.isEmpty()) return false;
+        if (create)
+            QMessageBox::information(parent, QObject::tr("Keep your keyfile safe"),
+                QObject::tr("Your keyfile is now part of your wallet's lock. <b>Back it up</b> "
+                            "(e.g. a USB stick) and keep it private — if you lose it, the encrypted "
+                            "data can't be read; if someone copies it%1, they hold part of the key.")
+                .arg(type == SecureStore::SecretKeyfile ? QObject::tr(" and it's your only factor")
+                                                        : QString()));
+    }
+
+    if (type == SecureStore::SecretPassword || type == SecureStore::SecretBoth) {
+        bool ok = false;
+        QString p1 = QInputDialog::getText(parent,
+            create ? QObject::tr("Set password") : QObject::tr("Enter password"),
+            QObject::tr("Wallet data password:"), QLineEdit::Password, "", &ok);
+        if (!ok) return false;
+        if (create) {
+            if (p1.isEmpty()) {
+                QMessageBox::warning(parent, QObject::tr("Set password"),
+                    QObject::tr("The password can't be empty."));
+                return false;
+            }
+            QString p2 = QInputDialog::getText(parent, QObject::tr("Confirm password"),
+                QObject::tr("Re-enter the password to confirm:"), QLineEdit::Password, "", &ok);
+            if (!ok) return false;
+            if (p1 != p2) {
+                QMessageBox::warning(parent, QObject::tr("Confirm password"),
+                    QObject::tr("The passwords didn't match. Try again."));
+                return false;
+            }
+        }
+        password = p1;
+    }
+    return true;
+}
+
+// A small frameless splash shown while the multi-second Argon2id derivation runs on a worker
+// thread. The ZCL logo and the indeterminate progress bar animate because the main thread keeps
+// pumping the event loop (the heavy crypto is off-thread), so the user is never left staring at
+// a frozen, blank screen for a few seconds after typing the password.
+class DeriveSplash : public QWidget {
+public:
+    DeriveSplash(const QString& msg, QWidget* parent)
+        : QWidget(parent, Qt::SplashScreen | Qt::FramelessWindowHint) {
+        setObjectName("DeriveSplash");
+        setFixedSize(380, 320);
+        setStyleSheet("#DeriveSplash { background:#26292d; border:1px solid #ce742f; }");
+
+        auto v = new QVBoxLayout(this);
+        v->setContentsMargins(24, 24, 24, 24);
+        v->setSpacing(16);
+        v->setAlignment(Qt::AlignCenter);
+
+        auto logo = new QLabel(this);
+        logo->setAlignment(Qt::AlignCenter);
+        logoMovie = new QMovie(":/img/res/logobig.gif", QByteArray(), this);
+        if (logoMovie->isValid()) {
+            logoMovie->setScaledSize(QSize(180, 180));
+            logo->setMovie(logoMovie);
+            logoMovie->start();
+        } else {
+            QPixmap pm(":/img/res/logobig.gif");
+            if (!pm.isNull())
+                logo->setPixmap(pm.scaled(180, 180, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+        }
+        v->addWidget(logo);
+
+        auto title = new QLabel(QObject::tr("ZclWallet"), this);
+        title->setAlignment(Qt::AlignCenter);
+        title->setStyleSheet("color:#ce742f; font-size:18px; font-weight:bold;");
+        v->addWidget(title);
+
+        auto text = new QLabel(msg, this);
+        text->setAlignment(Qt::AlignCenter);
+        text->setStyleSheet("color:#e0e0e0;");
+        v->addWidget(text);
+
+        auto bar = new QProgressBar(this);
+        bar->setRange(0, 0);                 // indeterminate / busy animation
+        bar->setTextVisible(false);
+        bar->setFixedHeight(8);
+        v->addWidget(bar);
+    }
+    QMovie* logoMovie = nullptr;
+};
+
+// Run `work` (the heavy key derivation) on a worker thread while the splash animates on the main
+// thread. Returns work()'s result. The work lambda must touch no GUI objects (it doesn't).
+static bool runWithSplash(QWidget* parent, const QString& msg, std::function<bool()> work) {
+    DeriveSplash splash(msg, parent);
+    if (QScreen* scr = QGuiApplication::primaryScreen()) {
+        QRect g = scr->geometry();
+        splash.move(g.center() - QPoint(splash.width() / 2, splash.height() / 2));
+    }
+    splash.show();
+    splash.raise();
+    QApplication::processEvents();
+
+    std::atomic<bool> finished(false);
+    bool result = false;
+    std::thread worker([&]() { result = work(); finished.store(true); });
+    while (!finished.load()) {
+        QApplication::processEvents(QEventLoop::AllEvents, 30);
+        QThread::msleep(15);
+    }
+    worker.join();
+    splash.close();
+    QApplication::processEvents();
+    return result;
+}
+
+bool SecureStore::bootstrap(QWidget* parent) {
+    if (!verifierExists()) {
+        QMessageBox::information(parent, QObject::tr("Protect your wallet data"),
+            QObject::tr(
+            "<b>This wallet now encrypts the sensitive files it stores on your computer.</b><br><br>"
+            "Your shielded <b>transaction history</b>, <b>address labels</b> and turnstile plan "
+            "are written to disk. Until now some of these were in plain text — "
+            "readable by anyone with access to this machine or a backup of it.<br><br>"
+            "You'll set a <b>password and/or a keyfile</b> now. It encrypts and decrypts those files "
+            "with a strong cipher cascade (XChaCha20-Poly1305 + AES-256), and in future it will also "
+            "unlock the wallet's own multi-cipher key encryption.<br><br>"
+            "<b>There is no recovery.</b> If you lose your password/keyfile, the encrypted "
+            "history/labels cannot be read — you can only purge them and start fresh (your coins are "
+            "safe in wallet.dat regardless)."));
+
+        // Choose the unlock factor(s).
+        QMessageBox choose(parent);
+        choose.setIcon(QMessageBox::Question);
+        choose.setWindowTitle(QObject::tr("Choose how to unlock"));
+        choose.setText(QObject::tr("How do you want to protect your wallet data?"));
+        choose.setInformativeText(QObject::tr(
+            "<b>Password</b> — something you remember.<br>"
+            "<b>Keyfile</b> — a file you keep (e.g. on a USB stick); nothing to memorise.<br>"
+            "<b>Both</b> — strongest: a stolen disk needs your keyfile <i>and</i> your password."));
+        QPushButton* bPw   = choose.addButton(QObject::tr("Password"), QMessageBox::AcceptRole);
+        QPushButton* bKf   = choose.addButton(QObject::tr("Keyfile"),  QMessageBox::AcceptRole);
+        QPushButton* bBoth = choose.addButton(QObject::tr("Both"),     QMessageBox::AcceptRole);
+        QPushButton* bQuit = choose.addButton(QObject::tr("Quit"),     QMessageBox::RejectRole);
+        choose.setDefaultButton(bPw);
+        choose.exec();
+        if (choose.clickedButton() == bQuit) return false;
+        SecretType type = (choose.clickedButton() == bKf)   ? SecretKeyfile
+                        : (choose.clickedButton() == bBoth) ? SecretBoth
+                                                            : SecretPassword;
+
+        for (;;) {
+            QString pw, kf;
+            if (!promptSecret(parent, type, /*create*/ true, pw, kf)) {
+                // Let them re-pick the factor or quit rather than dead-ending.
+                auto again = QMessageBox::question(parent, QObject::tr("Set up encryption"),
+                    QObject::tr("Encryption setup wasn't completed. Try again?"),
+                    QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+                if (again == QMessageBox::Yes) continue;
+                return false;
+            }
+            bool created = runWithSplash(parent, QObject::tr("Encrypting your wallet data…"),
+                [&]() { return createMaster(type, pw, kf); });
+            if (!created) {
+                QMessageBox::critical(parent, QObject::tr("Encryption setup failed"),
+                    QObject::tr("Could not initialise the encrypted store. This can happen if the "
+                                "keyfile is unreadable, or if this machine couldn't allocate the "
+                                "~1 GiB needed for the strong key derivation. Aborting for safety."));
+                return false;
+            }
+            return true;
+        }
+    }
+
+    // Returning user — unlock with the stored factor(s); retry / reset / quit on failure.
+    SecretType type = storedSecretType();
+    for (;;) {
+        QString pw, kf;
+        if (!promptSecret(parent, type, /*create*/ false, pw, kf)) {
+            // Treat a cancel as "give me the wrong-secret choices" rather than a silent quit.
+        } else if (runWithSplash(parent, QObject::tr("Decrypting your wallet data…"),
+                                 [&]() { return unlock(type, pw, kf); })) {
+            return true;
+        }
+
+        QMessageBox box(parent);
+        box.setIcon(QMessageBox::Warning);
+        box.setWindowTitle(QObject::tr("Couldn't unlock"));
+        box.setText(QObject::tr("That password/keyfile didn't unlock your wallet data."));
+        box.setInformativeText(QObject::tr(
+            "Try again, or <b>reset</b> — which permanently deletes the encrypted transaction "
+            "history, address labels and turnstile plan so you can start fresh. "
+            "Your coins are NOT affected (they live in wallet.dat)."));
+        QPushButton* retry = box.addButton(QObject::tr("Try again"), QMessageBox::AcceptRole);
+        QPushButton* reset = box.addButton(QObject::tr("Reset (delete data)"), QMessageBox::DestructiveRole);
+        QPushButton* quit  = box.addButton(QObject::tr("Quit"), QMessageBox::RejectRole);
+        box.setDefaultButton(retry);
+        box.exec();
+
+        if (box.clickedButton() == quit) return false;
+        if (box.clickedButton() == reset) {
+            auto sure = QMessageBox::warning(parent, QObject::tr("Confirm reset"),
+                QObject::tr("Permanently delete the encrypted wallet data and start fresh? "
+                            "This cannot be undone."),
+                QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+            if (sure == QMessageBox::Yes) {
+                purgeAllData();
+                return bootstrap(parent);   // fall back into first-run setup flow
+            }
+        }
+        // else: retry loop
+    }
+}

--- a/src/securestore.h
+++ b/src/securestore.h
@@ -1,0 +1,80 @@
+#ifndef SECURESTORE_H
+#define SECURESTORE_H
+
+#include "precompiled.h"
+
+// SecureStore — the wallet's master-password-derived encryption for every sensitive file the GUI
+// writes to disk (transaction history, address labels, turnstile plan, …).
+//
+// Threat model: a local adversary who can read the user's disk/AppData (stolen laptop, backup
+// leak, forensic image) must learn NOTHING about the user's shielded activity from our files.
+//
+// Cryptography (see docs/OPSEC_ENCRYPTION.md):
+//   • KDF:      Argon2id (crypto_pwhash), SENSITIVE params (~1 GiB, multi-second) → 256-bit master
+//               key. Memory-hard, the real front line against password brute-force.
+//   • Cipher:   a TWO-LAYER AEAD CASCADE with independent subkeys (crypto_kdf / BLAKE2b):
+//                 inner = XChaCha20-Poly1305  (stream family, 192-bit random nonce)
+//                 outer = AES-256-GCM         (block family; cipher-family diversity)
+//               If AES-NI is unavailable (e.g. some ARM) the outer layer falls back to a second,
+//               independent-key XChaCha20-Poly1305 — recorded in the blob's mode byte so files
+//               stay self-describing. A cryptanalytic break of either cipher still leaves the data
+//               sealed by the other. 256-bit keys ⇒ ~128-bit post-quantum (Grover) — quantum-ample
+//               for symmetric, password-based encryption.
+//
+// The master key lives only in mlock'd memory for the session and is zeroed on lock()/exit.
+
+class SecureStore {
+public:
+    static SecureStore* getInstance();
+
+    // How the master key's secret is supplied. A keyfile is any file the user keeps elsewhere
+    // (USB stick, etc.); its contents are hashed (BLAKE2b) and stretched by Argon2id just like a
+    // password, so a stolen disk alone — without the keyfile — can't derive the key.
+    enum SecretType { SecretPassword = 0, SecretKeyfile = 1, SecretBoth = 2 };
+
+    // --- lifecycle -------------------------------------------------------
+    bool verifierExists() const;                 // has a master secret ever been set?
+    SecretType storedSecretType() const;         // what kind of secret unlocks this wallet?
+    bool isUnlocked() const { return unlocked; }
+    bool createMaster(SecretType type, const QString& password, const QString& keyfilePath);
+    bool unlock(SecretType type, const QString& password, const QString& keyfilePath);
+    void lock();                                 // zero the in-memory key
+
+    // Interactive startup: first-run notice + set-password, or unlock with a
+    // retry/reset/quit choice on a wrong password. Returns false if the user declined
+    // (the caller should then refuse to start, so nothing is ever written in the clear).
+    bool bootstrap(QWidget* parent);
+
+    // --- encrypted file I/O (atomic, 0600) -------------------------------
+    bool writeFile(const QString& path, const QByteArray& plain);
+    bool readFile(const QString& path, QByteArray& plainOut);   // false if missing/corrupt/locked
+
+    // Read a legacy plaintext file and transparently migrate it to an encrypted one
+    // (write `encPath`, then delete `legacyPath`). Returns the plaintext bytes either way.
+    // Used by the stores so old wallets upgrade in place on first unlock.
+    QByteArray migrateIfNeeded(const QString& legacyPath, const QString& encPath);
+
+    // --- raw blob crypto (used by the above + the verifier/canary) -------
+    QByteArray encrypt(const QByteArray& plain);
+    bool       decrypt(const QByteArray& blob, QByteArray& plainOut);
+
+    // --- reset -----------------------------------------------------------
+    static QString dataDir();
+    void purgeAllData();          // delete every managed file + the verifier, then lock
+
+private:
+    SecureStore();
+    ~SecureStore();
+
+    // Build the raw secret bytes fed to Argon2id from a password and/or a keyfile.
+    QByteArray buildSecret(SecretType type, const QString& password, const QString& keyfilePath) const;
+    bool   deriveMaster(const QByteArray& secret, const unsigned char* salt,
+                        quint64 ops, quint64 mem);
+    QString verifierPath() const;
+
+    bool          unlocked = false;
+    unsigned char masterKey[32];  // crypto_kdf_KEYBYTES; mlock'd while unlocked
+    bool          keyLocked = false;
+};
+
+#endif // SECURESTORE_H

--- a/src/senttxstore.cpp
+++ b/src/senttxstore.cpp
@@ -1,48 +1,50 @@
 #include "senttxstore.h"
 #include "settings.h"
+#include "securestore.h"
 
-/// Get the location of the app data file to be written. 
-QString SentTxStore::writeableFile() {
-    auto filename = QStringLiteral("senttxstore.dat");
-
+// Helper: build a path in the app data dir, with the testnet- prefix when needed.
+static QString sentTxPath(const QString& filename) {
     auto dir = QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
     if (!dir.exists())
         QDir().mkpath(dir.absolutePath());
-
-    if (Settings::getInstance()->isTestnet()) {
-        return dir.filePath("testnet-" % filename);
-    } else {
-        return dir.filePath(filename);
-    }
+    return Settings::getInstance()->isTestnet() ? dir.filePath("testnet-" % filename)
+                                                : dir.filePath(filename);
 }
 
-// delete the sent history. 
+/// The encrypted store (current format). Sent z-tx history is OPSEC-sensitive (recipient
+/// addresses + amounts for shielded sends the daemon can't even see), so it is encrypted at rest
+/// via SecureStore — written atomically, owner-only (0600).
+QString SentTxStore::writeableFile() {
+    return sentTxPath(QStringLiteral("senttxstore.enc"));
+}
+
+// The legacy plaintext file, migrated to .enc on first read.
+static QString legacyFile() {
+    return sentTxPath(QStringLiteral("senttxstore.dat"));
+}
+
+// delete the sent history.
 void SentTxStore::deleteHistory() {
-    QFile data(writeableFile());
-    data.remove();
-    data.close();
+    QFile::remove(writeableFile());
+    QFile::remove(legacyFile());
 }
 
 QList<TransactionItem> SentTxStore::readSentTxFile() {
-    QFile data(writeableFile());
-    if (!data.exists()) {
+    // Reads the encrypted store; transparently migrates a legacy plaintext senttxstore.dat.
+    QByteArray bytes = SecureStore::getInstance()->migrateIfNeeded(legacyFile(), writeableFile());
+    if (bytes.isEmpty())
         return QList<TransactionItem>();
-    }
-    
-    QJsonDocument jsonDoc;
-    
-    data.open(QFile::ReadOnly);    
-    jsonDoc = QJsonDocument::fromJson(data.readAll());
-    data.close();
+
+    QJsonDocument jsonDoc = QJsonDocument::fromJson(bytes);
 
     QList<TransactionItem> items;
 
     for (auto i : jsonDoc.array()) {
         auto sentTx = i.toObject();
-        TransactionItem t{"send", (qint64)sentTx["datetime"].toVariant().toLongLong(), 
-                          sentTx["address"].toString(), 
-                          sentTx["txid"].toString(), 
-                          sentTx["amount"].toDouble() + sentTx["fee"].toDouble(), 
+        TransactionItem t{"send", (qint64)sentTx["datetime"].toVariant().toLongLong(),
+                          sentTx["address"].toString(),
+                          sentTx["txid"].toString(),
+                          sentTx["amount"].toDouble() + sentTx["fee"].toDouble(),
                           0, sentTx["from"].toString(), ""};
         items.push_back(t);
     }
@@ -55,33 +57,15 @@ void SentTxStore::addToSentTx(Tx tx, QString txid) {
     if (!Settings::getInstance()->getSaveZtxs())
         return;
 
-    // Also, only store outgoing txs where the from address is a z-Addr. Else, regular zclassicd 
+    // Also, only store outgoing txs where the from address is a z-Addr. Else, regular zclassicd
     // stores it just fine
-    if (!tx.fromAddr.startsWith("z")) 
+    if (!tx.fromAddr.startsWith("z"))
         return;
 
-    QFile data(writeableFile());
-    QJsonDocument jsonDoc;
-
-    // If data doesn't exist, then create a blank one
-    if (!data.exists()) {
-        QJsonArray a;
-        jsonDoc.setArray(a);
-
-        QFile newFile(writeableFile());
-        newFile.open(QFile::WriteOnly);
-        // 0600: this file records every outgoing shielded send (recipient addresses
-        // + amounts) as plaintext JSON. Restrict it to the owner so other local
-        // users/processes cannot harvest the user's private send history. (On
-        // Windows the POSIX bits map weakly; this mainly hardens Linux/macOS.)
-        newFile.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
-        newFile.write(jsonDoc.toJson());
-        newFile.close();
-    } else {
-        data.open(QFile::ReadOnly);    
-        jsonDoc = QJsonDocument().fromJson(data.readAll());
-        data.close();
-    }
+    // Load the existing (encrypted) history, migrating any legacy plaintext first.
+    QByteArray existing = SecureStore::getInstance()->migrateIfNeeded(legacyFile(), writeableFile());
+    QJsonDocument jsonDoc = existing.isEmpty() ? QJsonDocument(QJsonArray())
+                                               : QJsonDocument::fromJson(existing);
 
     // Calculate total amount in this tx
     double totalAmount = 0;
@@ -112,11 +96,6 @@ void SentTxStore::addToSentTx(Tx tx, QString txid) {
 
     jsonDoc.setArray(list);
 
-    QFile writer(writeableFile());
-    if (writer.open(QFile::WriteOnly | QFile::Truncate)) {
-        // 0600 owner-only (see above): this is the plaintext shielded send history.
-        writer.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
-        writer.write(jsonDoc.toJson());
-    }
-    writer.close();
+    // Encrypted, atomic, owner-only write via SecureStore.
+    SecureStore::getInstance()->writeFile(writeableFile(), jsonDoc.toJson());
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -291,6 +291,15 @@ void Settings::setSaveZtxs(bool save) {
     QSettings().setValue("options/savesenttx", save);
 }
 
+bool Settings::getSaveDebugLog() {
+    // OPSEC: the debug log is plaintext on disk, so default OFF. Opt-in for diagnostics.
+    return QSettings().value("options/savedebuglog", false).toBool();
+}
+
+void Settings::setSaveDebugLog(bool save) {
+    QSettings().setValue("options/savedebuglog", save);
+}
+
 bool Settings::getKeepInTray() {
     // Default ON: closing the window keeps the node warm in the tray so RE-OPENING
     // is instant (attaches to the already-loaded daemon) instead of paying the

--- a/src/settings.h
+++ b/src/settings.h
@@ -58,6 +58,10 @@ public:
     bool    getSaveZtxs();
     void    setSaveZtxs(bool save);
 
+    // OPSEC: write the plaintext debug log to disk only when explicitly enabled (default OFF).
+    bool    getSaveDebugLog();
+    void    setSaveDebugLog(bool save);
+
     // Opt-in: keep ZclWallet (and its embedded node) running in the system tray
     // when the window is closed, so the next launch is instant instead of paying
     // the ~1-minute node warmup again. Default OFF -> behaves exactly as before.

--- a/src/turnstile.cpp
+++ b/src/turnstile.cpp
@@ -3,6 +3,7 @@
 #include "balancestablemodel.h"
 #include "rpc.h"
 #include "settings.h"
+#include "securestore.h"
 
 using json = nlohmann::json;
 
@@ -19,22 +20,25 @@ void printPlan(QList<TurnstileMigrationItem> plan) {
     }
 }
 
-QString Turnstile::writeableFile() {
-    auto filename = QStringLiteral("turnstilemigrationplan.dat");
-
+static QString turnstilePath(const QString& filename) {
     auto dir = QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
     if (!dir.exists())
         QDir().mkpath(dir.absolutePath());
+    return Settings::getInstance()->isTestnet() ? dir.filePath("testnet-" % filename)
+                                                : dir.filePath(filename);
+}
 
-    if (Settings::getInstance()->isTestnet()) {
-        return dir.filePath("testnet-" % filename);
-    } else {
-        return dir.filePath(filename);
-    }
+QString Turnstile::writeableFile() {
+    return turnstilePath(QStringLiteral("turnstilemigrationplan.enc"));
+}
+
+static QString turnstileLegacyFile() {
+    return turnstilePath(QStringLiteral("turnstilemigrationplan.dat"));
 }
 
 void Turnstile::removeFile() {
-    QFile(writeableFile()).remove();
+    QFile::remove(writeableFile());
+    QFile::remove(turnstileLegacyFile());
 }
 
 // Data stream write/read methods for migration items
@@ -53,24 +57,24 @@ void Turnstile::writeMigrationPlan(QList<TurnstileMigrationItem> plan) {
     //qDebug() << QString("Writing plan");
     printPlan(plan);
 
-    QFile file(writeableFile());
-    file.open(QIODevice::ReadWrite | QIODevice::Truncate);
-    QDataStream out(&file);   // we will serialize the data into the file
-    out << plan;
-    file.close();
+    // The migration plan reveals z→t→z linkage — encrypted at rest.
+    QByteArray bytes;
+    {
+        QDataStream out(&bytes, QIODevice::WriteOnly);
+        out << plan;
+    }
+    SecureStore::getInstance()->writeFile(writeableFile(), bytes);
 }
 
 QList<TurnstileMigrationItem> Turnstile::readMigrationPlan() {
-    QFile file(writeableFile());
-    
     QList<TurnstileMigrationItem> plan;
-    if (!file.exists()) return plan;
 
-    file.open(QIODevice::ReadOnly);
-    QDataStream in(&file);    // read the data serialized from the file
-    in >> plan; 
+    // Read the encrypted plan; migrate a legacy plaintext .dat on first read.
+    QByteArray bytes = SecureStore::getInstance()->migrateIfNeeded(turnstileLegacyFile(), writeableFile());
+    if (bytes.isEmpty()) return plan;
 
-    file.close();
+    QDataStream in(&bytes, QIODevice::ReadOnly);
+    in >> plan;
 
     // Sort to see when the next step is.
     std::sort(plan.begin(), plan.end(), [&] (auto a, auto b) {

--- a/tests/shim/securestore.h
+++ b/tests/shim/securestore.h
@@ -1,0 +1,68 @@
+#ifndef SECURESTORE_H
+#define SECURESTORE_H
+// ============================================================================
+// TEST SHIM securestore.h  (L0 unit suite — tst_logic)
+//
+// A DELIBERATELY transparent, no-encryption stand-in for src/securestore.h.
+// The real SecureStore pulls in libsodium (Argon2id + the AEAD cascade); the L0
+// suite links NO libsodium, so this shim shadows it via INCLUDEPATH ordering
+// (shim/ ahead of ../src in tests.pro) and stores bytes verbatim instead.
+//
+// It preserves the on-disk *contract* the senttxstore tests assert — files are
+// written atomically, owner-only (0600), under the same path senttxstore.cpp
+// asks for — so G1 (write gating) and G4 (0600 / testnet-prefixed name) stay
+// meaningful. The cipher itself is validated separately against real libsodium;
+// here we only need the store plumbing to compile and round-trip.
+//
+// NOTE: no src/ file is modified — substitution happens purely via tests.pro.
+// ============================================================================
+#include <QString>
+#include <QByteArray>
+#include <QFile>
+#include <QSaveFile>
+#include <QFileDevice>
+#include <QIODevice>
+
+class SecureStore {
+public:
+    static SecureStore* getInstance() { static SecureStore inst; return &inst; }
+
+    bool isUnlocked() const { return true; }
+
+    // Atomic, owner-only (0600) write of the bytes verbatim (no encryption at L0).
+    bool writeFile(const QString& path, const QByteArray& plain) {
+        QSaveFile f(path);
+        if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) return false;
+        if (f.write(plain) != plain.size()) { f.cancelWriting(); return false; }
+        if (!f.commit()) return false;
+        QFile::setPermissions(path, QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+        return true;
+    }
+
+    bool readFile(const QString& path, QByteArray& plainOut) {
+        QFile f(path);
+        if (!f.exists() || !f.open(QIODevice::ReadOnly)) return false;
+        plainOut = f.readAll();
+        f.close();
+        return true;
+    }
+
+    // Same migration shape as the real store: prefer the .enc, else read the legacy
+    // file and rewrite it as .enc (dropping the original).
+    QByteArray migrateIfNeeded(const QString& legacyPath, const QString& encPath) {
+        QByteArray plain;
+        if (QFile::exists(encPath)) { readFile(encPath, plain); return plain; }
+        QFile lf(legacyPath);
+        if (lf.exists() && lf.open(QIODevice::ReadOnly)) {
+            plain = lf.readAll();
+            lf.close();
+            if (writeFile(encPath, plain)) lf.remove();
+        }
+        return plain;
+    }
+
+private:
+    SecureStore() {}
+};
+
+#endif // SECURESTORE_H

--- a/tests/tst_logic.cpp
+++ b/tests/tst_logic.cpp
@@ -511,7 +511,8 @@ void TestLogic::sentTxStore_perms_and_testnetName() {
     SentTxStore::addToSentTx(tx, "deadbeefcafetxid");
 
     // The file must exist under a "testnet-"-prefixed name in AppDataLocation.
-    QString expected = QDir(sandboxAppData()).filePath("testnet-senttxstore.dat");
+    // (Now the encrypted store: senttxstore.enc, written 0600 via SecureStore.)
+    QString expected = QDir(sandboxAppData()).filePath("testnet-senttxstore.enc");
     QVERIFY2(QFile::exists(expected), qPrintable("missing: " + expected));
 
     // Permissions must be owner-read + owner-write only (0600), no group/other.
@@ -533,7 +534,7 @@ void TestLogic::sentTxStore_perms_and_testnetName() {
 // =====================================================================
 void TestLogic::sentTxStore_gating() {
     Settings::getInstance()->setTestnet(false);
-    QString file = QDir(sandboxAppData()).filePath("senttxstore.dat");
+    QString file = QDir(sandboxAppData()).filePath("senttxstore.enc");
 
     auto mkTx = [](const QString& from) {
         Tx tx; tx.fromAddr = from; tx.fee = 0.0001;

--- a/tests/widget/tst_widget.pro
+++ b/tests/widget/tst_widget.pro
@@ -55,6 +55,7 @@ SOURCES += \
     ../../src/3rdparty/qrcode/QrCode.cpp \
     ../../src/3rdparty/qrcode/QrSegment.cpp \
     ../../src/settings.cpp \
+    ../../src/securestore.cpp \
     ../../src/sendtab.cpp \
     ../../src/senttxstore.cpp \
     ../../src/txtablemodel.cpp \

--- a/zcl-qt-wallet.pro
+++ b/zcl-qt-wallet.pro
@@ -50,6 +50,7 @@ SOURCES += \
     src/3rdparty/qrcode/QrCode.cpp \
     src/3rdparty/qrcode/QrSegment.cpp \
     src/settings.cpp \
+    src/securestore.cpp \
     src/sendtab.cpp \
     src/senttxstore.cpp \
     src/txtablemodel.cpp \
@@ -76,6 +77,7 @@ HEADERS += \
     src/3rdparty/qrcode/QrSegment.hpp \
     src/3rdparty/json/json.hpp \
     src/settings.h \
+    src/securestore.h \
     src/txtablemodel.h \
     src/senttxstore.h \
     src/turnstile.h \


### PR DESCRIPTION
## What & why

insecure defaults inherited from zcash qt wallet

The GUI was writing three sensitive files to the app-data dir in **plaintext**, readable from a stolen laptop, a leaked backup, or disk image:

| File | Was | Sensitivity |
|---|---|---|
| `senttxstore.dat` | JSON: shielded send history (from/to z-addrs, amounts, fees, txids, times) | 🔴 critical — the daemon can't even see z→z sends; this is the *only* record |
| `addresslabels.dat` | address ↔ human label | 🔴 critical — deanonymizes addresses |
| `turnstilemigrationplan.dat` | z→t→z migration plan | 🟠 high — reveals linkage |
| `zcl-qt-wallet.log` | plaintext diagnostics | 🟡 medium — persistent |

This PR cherry-picks the **encryption-at-rest** functionality from the `zclassic3-gui` `opsec-encrypt-data` branch and adapts it to this fork (the chaff-send / zmessage features from that branch are **not** included — only the encryption).

## How

New `src/securestore.{h,cpp}` — one master secret, unlocked once at startup, encrypts every sensitive file through a single container:

- **KDF:** Argon2id `crypto_pwhash`, **SENSITIVE** params (~1 GiB, multi-second), strict — no silent downgrade. Params recorded in the verifier so unlock always reproduces the key.
- **Cipher:** a two-layer AEAD cascade with independent `crypto_kdf`/BLAKE2b subkeys — **XChaCha20-Poly1305 (inner) → AES-256-GCM (outer)**, falling back to a second independent-key XChaCha20 where AES-NI is absent (recorded in the blob's `mode` byte, so files stay self-describing). A break of either cipher still leaves the data sealed by the other.
- **Unlock factors:** password, keyfile, or both (`Argon2id(BLAKE2b(pw‖kf))`).
- **Key hygiene:** master key `sodium_mlock`'d + `sodium_memzero`'d on lock/exit; files written atomically `0600`, data dir `0700`.
- **UX:** first-run notice + factor chooser; returning runs prompt to unlock **before any store touches disk** and refuse to start on cancel (never fall back to plaintext). Wrong secret → retry / reset / quit (reset purges encrypted data; **coins live in `wallet.dat` and are never touched**). Derivation runs on a worker thread behind an animated splash so the UI never freezes.
- **Migration:** legacy plaintext `*.dat` is transparently read, re-written as `*.enc`, and the cleartext original deleted on first unlock.
- **Debug log:** now **OFF by default** (opt-in `options/savedebuglog`).

Full design + threat model + file audit: `docs/OPSEC_ENCRYPTION.md`.

**Residual (documented, honest):** the daemon's RPC password must stay readable in `zclassic.conf` because the node itself reads it — encrypting only the GUI's copy would be theatre.

## Files

- **New:** `src/securestore.{h,cpp}`, `docs/OPSEC_ENCRYPTION.md`, `tests/shim/securestore.h`
- **Wired:** `senttxstore.cpp`, `addressbook.{cpp,h}`, `turnstile.cpp` route through SecureStore; `main.cpp` unlocks before any store I/O; `mainwindow.cpp` gates the debug log; `settings.{cpp,h}` add the toggle; `zcl-qt-wallet.pro` + `tests/widget/tst_widget.pro` build the new TU.

## Testing

- The AEAD cascade was validated out-of-band against libsodium: **round-trip across both cipher modes** (AES-256-GCM outer and the XChaCha20 fallback), **wrong-key rejection**, **single-bit tamper detection**, and **empty-input** — all pass.
- L0 unit suite (`tst_logic`, links no libsodium) keeps building via a transparent passthrough `SecureStore` shim; the SentTxStore perms/gating tests now assert the `.enc` path and still verify the `0600`, testnet-prefixed write.

_Generated by [Claude Code]_